### PR TITLE
Allow git time since last commit to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I started chopping away at [Avit](https://github.com/robbyrussell/oh-my-zsh/blob
 What it does:
 
 - display current git branch
-- display colored time since last commit
+- display colored time since last commit (optional)
 - display state (clean/dirty) of the repo
 - display arrows indicating if you need to pull, push or if you are mid-rebase
 - set the terminal title to current command and directory
@@ -63,6 +63,12 @@ conflicts as well as the total number of conflicts by setting the
 This option uses `grep` and `ag` with the latter being a [much faster alternative](http://geoff.greer.fm/ag/).
 
 **If you don't have `ag` installed, this might slow your prompt down**.
+
+#### git time since last commit
+
+You can optionally hide the time since last commit by setting the
+`PROMPT_GEOMETRY_GIT_TIME` variable to false. You might want to
+do this if the prompt is too slow on large repositories.
 
 #### colorized symbol ▲
 

--- a/geometry.zsh
+++ b/geometry.zsh
@@ -54,7 +54,7 @@ PROMPT_GEOMETRY_COLORIZE_ROOT=${PROMPT_GEOMETRY_COLORIZE_ROOT:-false}
 GREP=$(which ag &> /dev/null && echo "ag" || echo "grep")
 
 prompt_geometry_git_time_since_commit() {
-  if [[ $(git log 2>&1 > /dev/null | grep -c "^fatal: bad default revision") == 0 ]]; then
+  if [[ $(git log -1 2>&1 > /dev/null | grep -c "^fatal: bad default revision") == 0 ]]; then
     # Get the last commit.
     last_commit=$(git log --pretty=format:'%at' -1 2> /dev/null)
     now=$(date +%s)

--- a/geometry.zsh
+++ b/geometry.zsh
@@ -46,6 +46,7 @@ GEOMETRY_PROMPT=$(prompt_geometry_colorize $GEOMETRY_COLOR_PROMPT $GEOMETRY_SYMB
 
 # Flags
 PROMPT_GEOMETRY_GIT_CONFLICTS=${PROMPT_GEOMETRY_GIT_CONFLICTS:-false}
+PROMPT_GEOMETRY_GIT_TIME=${PROMPT_GEOMETRY_GIT_TIME:-true}
 PROMPT_GEOMETRY_COLORIZE_SYMBOL=${PROMPT_GEOMETRY_COLORIZE_SYMBOL:-false}
 PROMPT_GEOMETRY_COLORIZE_ROOT=${PROMPT_GEOMETRY_COLORIZE_ROOT:-false}
 
@@ -165,7 +166,11 @@ prompt_geometry_git_info() {
       conflicts="$(prompt_geometry_git_conflicts) "
     fi
 
-    echo "$(prompt_geometry_git_symbol) $(prompt_geometry_git_branch) $conflicts:: $(prompt_geometry_git_time_since_commit) :: $(prompt_geometry_git_status)"
+    if $PROMPT_GEOMETRY_GIT_TIME; then
+      time=" $(prompt_geometry_git_time_since_commit) ::"
+    fi
+
+    echo "$(prompt_geometry_git_symbol) $(prompt_geometry_git_branch) $conflicts::$time $(prompt_geometry_git_status)"
   fi
 }
 


### PR DESCRIPTION
In an ideal world, we would be able to speed up the git commands to be imperceptible.
In a pragmatic world, we would use async to show the git info.
But today, we can at least disable because there is a 4 second delay on each prompt draw for one of my repositories.
