### PR TITLE
Remove local to fix error with zsh 5.0.8

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -175,7 +175,7 @@ prompt_geometry_git_info() {
 }
 
 prompt_geometry_hash_color() {
-  local colors=(2 3 4 6 9 12 14)
+  colors=(2 3 4 6 9 12 14)
 
   if (($(echotc Co) == 256)); then
     colors+=(99 155 47 26)


### PR DESCRIPTION
I had to do this because I was getting `prompt_geometry_hash_color:1: unknown file attribute:` errors. Maybe `declare -a colors` would have fixed it as well, but this seems to work.
