### PR TITLE
Fix `bad math expression: empty string` error (OSX)

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -182,7 +182,7 @@ prompt_geometry_hash_color() {
   fi
 
   local sum=0
-  for for i in {0..${#1}}; do
+  for i in {0..${#1}}; do
     ord=$(printf '%d' "'${1[$i]}")
     sum=$(($sum + $ord))
   done


### PR DESCRIPTION
A duplicate `for` declaration results in the aforementioned error,
particularly on OSX. `printf` will throw an error due to $i
being empty for the last index.

---

I'm unsure if the duplication is intentional or if it is a mere typo. Nevertheless, this resolves the described error for OSX El Capitan (10.11.5). It is considered a syntax error in bash.
