### PR TITLE
Fix issue with zsh 5.0.x with local variables and subshells

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -256,9 +256,7 @@ prompt_geometry_render() {
   PROMPT2=" $GEOMETRY_SYMBOL_RPROMPT "
 
   local exec_time=$prompt_geometry_command_exec_time
-  local git_info=$(prompt_geometry_git_info)
-  local virtualenv=$(prompt_geometry_virtualenv)
-  local right_prompt=($exec_time $virtualenv $git_info)
+  local right_prompt="$exec_time $(prompt_geometry_virtualenv) $(prompt_geometry_git_info)"
   RPROMPT=${(j/::/)right_prompt}
 }
 


### PR DESCRIPTION
Tested against `5.0.0` and `5.1`. I don't know the root cause of the problem. I should probably checkout zsh-users list or ask on #zsh channel.

Fixes #25 