### PR TITLE
Fix regression regarding locals on 5.0.0

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -249,9 +249,7 @@ prompt_geometry_set_title() {
 
 prompt_geometry_render_rprompt() {
     local exec_time=$prompt_geometry_command_exec_time
-    local git_info=$(prompt_geometry_git_info)
-    local virtualenv=$(prompt_geometry_virtualenv)
-    echo $exec_time $virtualenv $git_info
+    echo $exec_time $virtualenv $(prompt_geometry_git_info) $(prompt_geometry_virtualenv)
 }
 
 prompt_geometry_render() {


### PR DESCRIPTION
It looks like I caused a regression with `feature/async-git-prompt` branch https://github.com/frmendes/geometry/pull/26.

I think I messed up while trying to fix a merge issue. Should be fine by now.


Tested with `5.0.0`, `5.1` and `5.2`.

See https://github.com/frmendes/geometry/pull/29 and https://github.com/frmendes/geometry/issues/25