### PR TITLE
Fix git conflict check

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -60,7 +60,7 @@ PROMPT_GEOMETRY_GIT_TIME_SHORT_FORMAT=${PROMPT_GEOMETRY_GIT_TIME_SHORT_FORMAT:-t
 GEOMETRY_ASYNC_PROMPT_TMP_FILENAME=${GEOMETRY_ASYNC_PROMPT_TMP_FILENAME:-/tmp/geometry-prompt-git-info-}
 
 # Use ag if possible
-GREP=$(command -v ag >/dev/null 2>&1 && echo "ag" || echo "grep")
+GEOMETRY_GREP=$(command -v ag >/dev/null 2>&1 && echo "ag" || echo "grep")
 
 # from https://github.com/sindresorhus/pretty-time-zsh
 prompt_geometry_seconds_to_human_time() {
@@ -173,12 +173,12 @@ prompt_geometry_git_conflicts() {
   conflicts=$(git diff --name-only --diff-filter=U)
 
   if [[ ! -z $conflicts ]]; then
-    conflict_list=`$GREP -o '^=======$' $(echo $conflicts)`
+    conflict_list=`$GEOMETRY_GREP -cH '^=======$' $(echo $conflicts)`
 
-    raw_file_count=`echo $conflict_list | cut -d ':' -f1 | uniq | wc -l`
+    raw_file_count=`echo $conflict_list | cut -d ':' -f1 | wc -l`
     file_count=${raw_file_count##*( )}
 
-    raw_total=`echo $conflict_list | wc -l`
+    raw_total=`echo $conflict_list | cut -d ':' -f2 | paste -sd+ - | bc`
     total=${raw_total##*(  )}
 
     if [[ -z $total ]]; then

--- a/geometry.zsh
+++ b/geometry.zsh
@@ -171,18 +171,15 @@ prompt_geometry_git_symbol() {
 
 prompt_geometry_git_conflicts() {
   conflicts=$(git diff --name-only --diff-filter=U)
-  # echo adds a newline which we want to avoid
-  # Using -n prevents from using wc, which searches for newlines
-  # and returns 0 when a single file has conflicts
-  # Use grep instead
-  file_count=$(echo -n "$conflicts" | $GREP -c '^')
 
-  # $file_count contains the amount of files with conflicts
-  # in the **BEGINNING** of the merge/rebase.
-  if [ "$file_count" -gt 0 ]; then
-    # If we have fixed every conflict, $total will be empty
-    # So we will check and mark it as good if every conflict is solved
-    total=$($GREP -c '^=======$' $conflicts)
+  if [[ ! -z $conflicts ]]; then
+    conflict_list=`$GREP -o '^=======$' $(echo $conflicts)`
+
+    raw_file_count=`echo $conflict_list | cut -d ':' -f1 | uniq | wc -l`
+    file_count=${raw_file_count##*( )}
+
+    raw_total=`echo $conflict_list | wc -l`
+    total=${raw_total##*(  )}
 
     if [[ -z $total ]]; then
       text=$GEOMETRY_SYMBOL_GIT_CONFLICTS_SOLVED

--- a/geometry.zsh
+++ b/geometry.zsh
@@ -173,12 +173,12 @@ prompt_geometry_git_conflicts() {
   conflicts=$(git diff --name-only --diff-filter=U)
 
   if [[ ! -z $conflicts ]]; then
-    conflict_list=`$GEOMETRY_GREP -cH '^=======$' $(echo $conflicts)`
+    conflict_list=$($GEOMETRY_GREP -cH '^=======$' $(echo $conflicts))
 
-    raw_file_count=`echo $conflict_list | cut -d ':' -f1 | wc -l`
+    raw_file_count=$(echo $conflict_list | cut -d ':' -f1 | wc -l)
     file_count=${raw_file_count##*( )}
 
-    raw_total=`echo $conflict_list | cut -d ':' -f2 | paste -sd+ - | bc`
+    raw_total=$(echo $conflict_list | cut -d ':' -f2 | paste -sd+ - | bc)
     total=${raw_total##*(  )}
 
     if [[ -z $total ]]; then


### PR DESCRIPTION
I was able to reproduce it so I took the time to fix #17.

`grep` and `ag` were acting out when the list of conflicting files spanned across multiple lines.

In addition to fixing that, I also changed the checks to update the number of files with conflicts. Previously, it used the total number of conflicting files provided by git. This meant that if a file was resolved, it would still show up on the prompt count. Now, if there are no more conflicts in that same file, it won't be added to that count.