### PR TITLE
Ensure multiple concurrent async process are not run

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -306,7 +306,7 @@ prompt_geometry_setup_async_prompt() {
 
         # kill child if necessary
         if [[ "${GEOMETRY_ASYNC_PROMPT_PROC}" != 0 ]]; then
-            kill -s HUP $GEOMETRY_ASYNC_PROMPT_PROC &> /dev/null || :
+            kill -- -$(ps -o pgid= $GEOMETRY_ASYNC_PROMPT_PROC | grep -o '[0-9]*') &> /dev/null || :
         fi
 
         -prompt-geometry-async-function &!


### PR DESCRIPTION
Kill process and subprocess launched in async function.

This issue could cause to have multiple `prompt_geometry_setup_async_prompt` functions running in parallel if the `git_info` prompt is slow enough or the user hits `enter` key in a fast sequence.

- [x] Test on BSD/GNU (Mac, FreeBSD, Linux variants)