### PR TITLE
load zsh/datetime module for EPOCHSECONDS support

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -342,6 +342,7 @@ prompt_geometry_setup_async_prompt() {
 }
 
 prompt_geometry_setup() {
+  zmodload zsh/datetime
   autoload -U add-zsh-hook
 
   if $PROMPT_GEOMETRY_COLORIZE_SYMBOL; then


### PR DESCRIPTION
Might want to have an `|| { #disable prompt_geometry_exec_time }` in the future, but I needed this for EPOCHSECONDS to work