### PR TITLE
Small performance improvement on large repos

### DIFF
--- a/plugins/git/plugin.zsh
+++ b/plugins/git/plugin.zsh
@@ -55,7 +55,11 @@ prompt_geometry_git_branch() {
 
 prompt_geometry_git_status() {
   if test -z "$(git status --porcelain --ignore-submodules HEAD)"; then
-    echo $GEOMETRY_GIT_CLEAN
+    if test -z "$(git ls-files --others --modified --exclude-standard)"; then
+      echo $GEOMETRY_GIT_CLEAN
+    else
+      echo $GEOMETRY_GIT_DIRTY
+    fi
   else
     echo $GEOMETRY_GIT_DIRTY
   fi

--- a/plugins/git/plugin.zsh
+++ b/plugins/git/plugin.zsh
@@ -54,7 +54,7 @@ prompt_geometry_git_branch() {
 }
 
 prompt_geometry_git_status() {
-  if test -z "$(git status --porcelain --ignore-submodules)"; then
+  if test -z "$(git status --porcelain --ignore-submodules HEAD)"; then
     echo $GEOMETRY_GIT_CLEAN
   else
     echo $GEOMETRY_GIT_DIRTY


### PR DESCRIPTION
 
    ▲ /path/to/large-repo time git status --porcelain --ignore-submodules &> /dev/null
    git status --porcelain --ignore-submodules &> /dev/null  0.69s user 0.03s system 99% cpu 0.733 total

    ▲ /path/to/large-repo time git status --porcelain --ignore-submodules HEAD &> /dev/null
    git status --porcelain --ignore-submodules HEAD &> /dev/null  0.20s user 0.00s system 99% cpu 0.206 total

It's a quite noticeable improvement but I don't know if I'm missing/breaking something up.

Partially fixes #60