### PR TITLE
Added if statements to fix spacing

### DIFF
--- a/lib/plugin.zsh
+++ b/lib/plugin.zsh
@@ -71,7 +71,7 @@ geometry_plugin_render() {
 
   for plugin in $_GEOMETRY_PROMPT_PLUGINS; do
     render=$(geometry_prompt_${plugin}_render)
-    if [[ $render != "" ]]; then
+    if [[ -n $render ]]; then
       rprompt+="$render$GEOMETRY_PLUGIN_SEPARATOR"
     fi
   done

--- a/plugins/git/plugin.zsh
+++ b/plugins/git/plugin.zsh
@@ -95,7 +95,24 @@ prompt_geometry_git_remote_check() {
 }
 
 prompt_geometry_git_symbol() {
-  echo "$(prompt_geometry_git_rebase_check) $(prompt_geometry_git_remote_check)"
+  local git_rebase="$(prompt_geometry_git_rebase_check)"
+  local git_remote="$(prompt_geometry_git_remote_check)"
+  local render=""
+
+  if [[ $git_rebase != "" ]]; then
+    render+="$git_rebase"
+    
+    if [[ $git_remote != "" ]]; then
+      render+=" $git_remote"
+    fi
+
+  fi
+
+  if [[ $git_remote != "" ]]; then
+    render+="$git_remote"
+  fi
+
+  echo -n $render
 }
 
 prompt_geometry_git_conflicts() {
@@ -140,7 +157,16 @@ geometry_prompt_git_render() {
       fi
     fi
 
-    echo -n "$(prompt_geometry_git_symbol) $(prompt_geometry_git_branch) $conflicts::$time $(prompt_geometry_git_status)"
+    local render="$(prompt_geometry_git_symbol)"
+
+    if [[ $render != "" ]]; then
+      render+=" "
+    fi
+
+    render+="$(prompt_geometry_git_branch) $conflicts::$time $(prompt_geometry_git_status)"
+
+    echo -n $render
+
   fi
 }
 

--- a/plugins/git/plugin.zsh
+++ b/plugins/git/plugin.zsh
@@ -95,20 +95,19 @@ prompt_geometry_git_remote_check() {
 }
 
 prompt_geometry_git_symbol() {
+  local render=""
   local git_rebase="$(prompt_geometry_git_rebase_check)"
   local git_remote="$(prompt_geometry_git_remote_check)"
-  local render=""
 
-  if [[ $git_rebase != "" ]]; then
+  if [[ -n $git_rebase ]]; then
     render+="$git_rebase"
-    
-    if [[ $git_remote != "" ]]; then
-      render+=" $git_remote"
-    fi
-
   fi
 
-  if [[ $git_remote != "" ]]; then
+  if [[ -n $git_rebase && -n $git_remote ]]; then
+    render+=" "
+  fi
+
+  if [[ -n $git_remote ]]; then
     render+="$git_remote"
   fi
 
@@ -159,14 +158,13 @@ geometry_prompt_git_render() {
 
     local render="$(prompt_geometry_git_symbol)"
 
-    if [[ $render != "" ]]; then
+    if [[ -n $render ]]; then
       render+=" "
     fi
 
     render+="$(prompt_geometry_git_branch) $conflicts::$time $(prompt_geometry_git_status)"
 
     echo -n $render
-
   fi
 }
 


### PR DESCRIPTION
Hello again -- sorry for the last pull request. I'm sending a new one after I thought about the code for a while.

Last PR: https://github.com/frmendes/geometry/pull/70

I added if statements since I believe the problem is that in certain cases, there are unnecessary spaces being generated.

--
**L98** `echo "$(prompt_geometry_git_rebase_check) $(prompt_geometry_git_remote_check)"`

1. Even when the functions `prompt_geometry_git_rebase_check()` and `prompt_geometry_git_remote_check()` both do not output anything, a space is generated in between the empty results of the two functions.
Unintended resulting string: `" "`

2. Another check to avoid an unnecessary space has to be made in the case that the first statement fails, but the second statement passes.
Unintended resulting string: `" $(prompt_geometry_git_remote_check)"`

--
**L143** `echo -n "$(prompt_geometry_git_symbol) $(prompt_geometry_git_branch) $conflicts::$time $(prompt_geometry_git_status)"`

3. An unnecessary space occurs after `prompt_geometry_git_symbol()` even if the function did not output anything. I added an if statement to check for that case. If the function does output something, then a space needs to be added.
Unintended resulting result: `" $(prompt_geometry_git_branch) $conflicts::$time $(prompt_geometry_git_status)"`

--- Edit 5:26 to make the post clearer