### PR TITLE
Add configuration for git plugin separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,20 +103,28 @@ You can find symbol configuration for specific plugins under the
 The following color definitions are available for configuration:
 
 ```shell
-GEOMETRY_COLOR_EXIT_VALUE="magenta" # prompt symbol color when exit value is != 0
-GEOMETRY_COLOR_PROMPT="white" # prompt symbol color
-GEOMETRY_COLOR_ROOT="red" # root prompt symbol color
-GEOMETRY_COLOR_DIR="blue" # current directory color
+GEOMETRY_COLOR_EXIT_VALUE="magenta"         # prompt symbol color when exit value is != 0
+GEOMETRY_COLOR_PROMPT="white"               # prompt symbol color
+GEOMETRY_COLOR_ROOT="red"                   # root prompt symbol color
+GEOMETRY_COLOR_DIR="blue"                   # current directory color
 ```
 
 You can find color configuration for specific plugins under the
 [plugins](/plugins) directory.
 
+
+### Misc
+
+```shell
+GEOMETRY_PROMPT_PREFIX="$'\n'"              # prefix prompt with a new line
+GEOMETRY_PLUGIN_SEPARATOR=" "               # use ' ' to separate right prompt parts
+```
+
 ### Features
 
 #### Async `RPROMPT`
 
-geometry runs `RPROMPT` asynchronously to avoid blocking on costly operations. This is enabled by default but you can disable it by setting `PROMPT_GEOMETRY_GIT_ASYNC` to `false`
+geometry runs `RPROMPT` asynchronously to avoid blocking on costly operations. This is enabled by default but you can disable it by setting `PROMPT_GEOMETRY_RPROMPT_ASYNC` to `false`
 
 #### Randomly colorize prompt symbol
 

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -77,4 +77,3 @@ PROMPT_GEOMETRY_GIT_TIME_SHOW_EMPTY=true    # whether to show time if there is n
 GEOMETRY_GIT_NO_COMMITS_MESSAGE="no commits"# message where repository has no commits
 GEOMETRY_GIT_SEPARATOR="::"                 # customize git character separator
 ```
-

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -48,10 +48,8 @@ GEOMETRY_SYMBOL_GIT_CLEAN="⬢"                 # when reapo has "clean" state
 GEOMETRY_SYMBOL_GIT_REBASE="\uE0A0"           # when in middle of rebase
 GEOMETRY_SYMBOL_GIT_UNPULLED="⇣"              # when there are unpulled changes
 GEOMETRY_SYMBOL_GIT_UNPUSHED="⇡"              # when there are unpushed changes
-GEOMETRY_SYMBOL_GIT_CONFLICTS_SOLVED="◆"      # when all conflicts have been
-solved
-GEOMETRY_SYMBOL_GIT_CONFLICTS_UNSOLVED="◈"    # when there are still unsolved
-conflicts
+GEOMETRY_SYMBOL_GIT_CONFLICTS_SOLVED="◆"      # when all conflicts have been solved
+GEOMETRY_SYMBOL_GIT_CONFLICTS_UNSOLVED="◈"    # when there are still unsolved conflicts
 ```
 
 ## Colors
@@ -60,7 +58,23 @@ conflicts
 GEOMETRY_COLOR_GIT_DIRTY=red                # when repo has "dirty" state
 GEOMETRY_COLOR_GIT_CLEAN=green              # when repo has "clean" state
 GEOMETRY_COLOR_GIT_CONFLICTS_UNSOLVED=red   # when there are unsolved conflicts
-GEOMETRY_COLOR_GIT_CONFLICTS_SOLVED=green   # when all conflicts have been
-solved
+GEOMETRY_COLOR_GIT_CONFLICTS_SOLVED=green   # when all conflicts have been solved
 GEOMETRY_COLOR_GIT_BRANCH=242               # branch name color
 ```
+
+## Flags
+
+```sh
+PROMPT_GEOMETRY_GIT_CONFLICTS=false         # show info if there is a merge conflict
+PROMPT_GEOMETRY_GIT_TIME=true               # display time since last commit
+PROMPT_GEOMETRY_GIT_TIME_LONG_FORMAT=false  # use long format for time since last commit
+PROMPT_GEOMETRY_GIT_TIME_SHOW_EMPTY=true    # whether to show time if there is no commits
+```
+
+## Misc
+
+```sh
+GEOMETRY_GIT_NO_COMMITS_MESSAGE="no commits"# message where repository has no commits
+GEOMETRY_GIT_SEPARATOR="::"                 # customize git character separator
+```
+

--- a/plugins/git/plugin.zsh
+++ b/plugins/git/plugin.zsh
@@ -29,6 +29,7 @@ PROMPT_GEOMETRY_GIT_TIME_SHOW_EMPTY=${PROMPT_GEOMETRY_GIT_TIME_SHOW_EMPTY:-true}
 
 # Misc configurations
 GEOMETRY_GIT_NO_COMMITS_MESSAGE=${GEOMETRY_GIT_NO_COMMITS_MESSAGE:-"no commits"}
+GEOMETRY_GIT_SEPARATOR=${GEOMETRY_GIT_SEPARATOR:-"::"}
 
 prompt_geometry_git_time_since_commit() {
   # Defaults to "", which would hide the git_time_since_commit block
@@ -152,7 +153,7 @@ geometry_prompt_git_render() {
     if $PROMPT_GEOMETRY_GIT_TIME; then
       local git_time_since_commit=$(prompt_geometry_git_time_since_commit)
       if [[ -n $git_time_since_commit ]]; then
-          time=" $git_time_since_commit ::"
+          time=" $git_time_since_commit $GEOMETRY_GIT_SEPARATOR"
       fi
     fi
 
@@ -162,7 +163,7 @@ geometry_prompt_git_render() {
       render+=" "
     fi
 
-    render+="$(prompt_geometry_git_branch) $conflicts::$time $(prompt_geometry_git_status)"
+    render+="$(prompt_geometry_git_branch) ${conflicts}${GEOMETRY_GIT_SEPARATOR}${time} $(prompt_geometry_git_status)"
 
     echo -n $render
   fi


### PR DESCRIPTION
Partially fixes #52 by adding configuration for git plugin.

![screen shot 2016-12-29 at 4 36 41 pm](https://cloud.githubusercontent.com/assets/1857707/21553084/08869bda-cde5-11e6-9ceb-0889380608d0.png)
