### PR TITLE
Add new built-in plugins to README.md

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -10,6 +10,8 @@ Available plugins:
 * [Exec Time](/plugins/exec_time)
 * [Git](/plugins/git)
 * [Hg](/plugins/hg)
+* [Node](/plugins/node)
+* [Ruby](/plugins/ruby)
 * [Virtualenv](/plugins/virtualenv)
 
 ## Default plugins


### PR DESCRIPTION
Added missing `ruby` and `node` entries to `README.md`