### PR TITLE
Avoid error message being displayed on a fast key-press sequence

### DIFF
--- a/plugins/node/plugin.zsh
+++ b/plugins/node/plugin.zsh
@@ -5,13 +5,12 @@ GEOMETRY_COLOR_NODE_NPM_VERSION=${GEOMETRY_COLOR_NODE_NPM_VERSION:-black}
 GEOMETRY_SYMBOL_NODE_NPM_VERSION=${GEOMETRY_SYMBOL_NODE_NPM_VERSION:-"⬡"}
 GEOMETRY_NODE_NPM_VERSION=$(prompt_geometry_colorize $GEOMETRY_COLOR_NODE_NPM_VERSION $GEOMETRY_SYMBOL_NODE_NPM_VERSION) 
 
+geometry_prompt_node_setup() {}
 
-geometry_prompt_node_setup(){} 
-
-geometry_prompt_node_render(){	
-    if (( $+commands[node] != 0 )); then
-        GEOMETRY_NODE_VERSION="$(node -v)"
-        GEOMETRY_NPM_VERSION="$(npm --version)" 
+geometry_prompt_node_render() {
+    if (( $+commands[node] )); then
+        GEOMETRY_NODE_VERSION="$(node -v 2> /dev/null)"
+        GEOMETRY_NPM_VERSION="$(npm --version 2> /dev/null)" 
         echo "$GEOMETRY_NODE_NPM_VERSION $GEOMETRY_NODE_VERSION ($GEOMETRY_NPM_VERSION)"
     fi
 }


### PR DESCRIPTION
On a fast key-press sequence (enter key), node may display the following error message:


```▲ ~ events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at exports._errnoException (util.js:1022:11)
```

What these changes do is capture the error output and redirect them to `/dev/null`.