### PR TITLE
widen prompt_geometry_hash_color range

### DIFF
--- a/lib/color.zsh
+++ b/lib/color.zsh
@@ -4,10 +4,10 @@ prompt_geometry_colorize() {
 }
 
 prompt_geometry_hash_color() {
-  colors=(2 3 4 6 9 12 14)
+  colors=(`seq 1 9`)
 
   if (($(echotc Co) == 256)); then
-    colors+=(99 155 47 26)
+    colors+=(`seq 17 230`)
   fi
 
   local sum=0


### PR DESCRIPTION
This should fix #87 - though there will be a lot more color 'collisions' depending on your eyesight, theme, etc. 

For example, these are colors 1-256 on tomorrow night eighties.

<img width="808" alt="screen shot 2017-02-06 at 9 07 45 pm" src="https://cloud.githubusercontent.com/assets/32407/22674877/58b172a8-ecb0-11e6-91ec-bb0cad2598c0.png">
