### PR TITLE
Initial proposal for 'starred' plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ fast™.
 
 ## Plugins
 
-geometry has an internal plugin architecture. The default plugins are `exec_time`, `git` and `hg`. But you can enable a variety of built-in plugins just by setting the `GEOMETRY_PROMPT_PLUGINS` variable in your own configuration files:
+geometry has an internal plugin architecture. The default plugins are `exec_time`, `git` and `hg`.
+But you can enable a variety of built-in plugins just by setting the `GEOMETRY_PROMPT_PLUGINS` variable in your own configuration files:
 
 ```sh
 GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg)
@@ -74,6 +75,12 @@ GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg)
 These plugins will load and display on the right prompt. You can check the
 documentation and configuration for each specific plugin in the
 [plugins](/plugins) directory.
+
+Some plugins support starring*, for example, if you * rustup, it will always display in the prompt, even in non-rust folders.
+
+```sh
+GEOMETRY_PROMPT_PLUGINS+=('rustup*')
+```
 
 geometry also supports your own custom plugins. See the plugin [documentation](/plugins/README.md) for
 instructions and examples.

--- a/lib/plugin.zsh
+++ b/lib/plugin.zsh
@@ -10,9 +10,16 @@ fi
 # List of active plugins
 typeset -ga _GEOMETRY_PROMPT_PLUGINS
 
+# List of starred plugins
+typeset -ga _GEOMETRY_PROMPT_PLUGINS_STARRED
+
 # Set up default plugins
 geometry_plugin_setup() {
   for plugin in $GEOMETRY_PROMPT_PLUGINS; do
+    if [[ $plugin[-1] == '*' ]]; then
+      plugin=${plugin%?}
+      _GEOMETRY_PROMPT_PLUGINS_STARRED+=$plugin
+    fi
     source "$GEOMETRY_ROOT/plugins/$plugin/plugin.zsh"
   done
 }
@@ -38,7 +45,7 @@ geometry_plugin_register() {
     return 1
   fi
 
-  if geometry_prompt_${plugin}_setup; then
+  if geometry_prompt_${plugin}_setup $_GEOMETRY_PROMPT_PLUGINS_STARRED[(r)$plugin]; then
     _GEOMETRY_PROMPT_PLUGINS+=$plugin
   fi
 }
@@ -54,6 +61,10 @@ geometry_plugin_unregister() {
 
   if [[ $+functions["geometry_prompt_${plugin}_shutdown"] != 0 ]]; then
     geometry_prompt_${plugin}_shutdown
+  fi
+
+  if [[ $_GEOMETRY_PROMPT_PLUGINS_STARRED[(r)$plugin] != "" ]]; then
+    _GEOMETRY_PROMPT_PLUGINS_STARRED[$_GEOMETRY_PROMPT_PLUGINS_STARRED[(i)$plugin]]=()
   fi
 
   _GEOMETRY_PROMPT_PLUGINS[$_GEOMETRY_PROMPT_PLUGINS[(i)$plugin]]=()

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -23,7 +23,7 @@ configuration files.
 
 
 ```sh
-GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg)
+GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg 'rustup*')
 ```
 
 *Note: if you're not sure where to put geometry configs, just add them to your `.zshrc`*
@@ -124,4 +124,18 @@ geometry_prompt_pretty_git_render() {
 
 geometry_plugin_register pretty_git
 
+```
+
+## Starring
+
+A user may decide to '*' a plugin. It is up the the plugin developer to figure out what that means, though
+usually it means 'always display this plugin'. A plugin will know if it is starred in the `setup()` function as argument 1.
+Maybe in the above example, it means to make a worse looking dirty git face:
+
+```sh
+
+geometry_prompt_pretty_git_setup() {
+  _GEOMETRY_PRETTY_GIT_STARRY_EYED=$1
+  [[ $_GEOMETRY_PRETTY_GIT_STARRY_EYED ]] && GEOMETRY_PRETTY_GIT_DIRTY="(>*.*)>"
+}
 ```

--- a/plugins/node/plugin.zsh
+++ b/plugins/node/plugin.zsh
@@ -5,7 +5,9 @@ GEOMETRY_COLOR_NODE_NPM_VERSION=${GEOMETRY_COLOR_NODE_NPM_VERSION:-black}
 GEOMETRY_SYMBOL_NODE_NPM_VERSION=${GEOMETRY_SYMBOL_NODE_NPM_VERSION:-"⬡"}
 GEOMETRY_NODE_NPM_VERSION=$(prompt_geometry_colorize $GEOMETRY_COLOR_NODE_NPM_VERSION $GEOMETRY_SYMBOL_NODE_NPM_VERSION) 
 
-geometry_prompt_node_setup() {}
+geometry_prompt_node_setup() {
+    starred=$1
+}
 
 geometry_prompt_node_render() {
     if (( $+commands[node] )); then

--- a/plugins/node/plugin.zsh
+++ b/plugins/node/plugin.zsh
@@ -6,15 +6,16 @@ GEOMETRY_SYMBOL_NODE_NPM_VERSION=${GEOMETRY_SYMBOL_NODE_NPM_VERSION:-"⬡"}
 GEOMETRY_NODE_NPM_VERSION=$(prompt_geometry_colorize $GEOMETRY_COLOR_NODE_NPM_VERSION $GEOMETRY_SYMBOL_NODE_NPM_VERSION) 
 
 geometry_prompt_node_setup() {
-    starred=$1
+    _GEOMETRY_NODE_STARRED=$1
 }
 
 geometry_prompt_node_render() {
-    if (( $+commands[node] )); then
-        GEOMETRY_NODE_VERSION="$(node -v 2> /dev/null)"
-        GEOMETRY_NPM_VERSION="$(npm --version 2> /dev/null)" 
-        echo "$GEOMETRY_NODE_NPM_VERSION $GEOMETRY_NODE_VERSION ($GEOMETRY_NPM_VERSION)"
-    fi
+    (( $+commands[node] )) || return
+    { [[ $_GEOMETRY_NODE_STARRED ]] || test -f package.json } || return
+
+    GEOMETRY_NODE_VERSION="$(node -v 2> /dev/null)"
+    GEOMETRY_NPM_VERSION="$(npm --version 2> /dev/null)"
+    echo "$GEOMETRY_NODE_NPM_VERSION $GEOMETRY_NODE_VERSION ($GEOMETRY_NPM_VERSION)"
 }
 
 geometry_plugin_register node

--- a/plugins/rustup/README.md
+++ b/plugins/rustup/README.md
@@ -1,12 +1,17 @@
 # Rustup
 
-Rustup plugin. Displays rust toolchain. Requires rustup_prompt_helper
+Rustup plugin. Displays the currently selected rust toolchain when in a directory or git repository with Cargo.toml
+It requires [rustup_prompt_helper][]. If starred*, will display in any working directory.
 
 ## Installation
 
     cargo install rustup_prompt_helper
 
 ## Configuration
+
+```sh
+GEOMETRY_PROMPT_PLUGINS+=('rustup*')
+```
 
 ### Colors
 
@@ -16,9 +21,10 @@ GEOMETRY_COLOR_RUSTUP_BETA="yellow"
 GEOMETRY_COLOR_RUSTUP_NIGHTLY="red"
 ```
 
-
 ### Symbols
 
 ```sh
 GEOMETRY_SYMBOL_RUSTUP="⚙"
 ```
+
+[rustup_prompt_helper]: https://github.com/ijanos/rustup_prompt_helper

--- a/plugins/rustup/plugin.zsh
+++ b/plugins/rustup/plugin.zsh
@@ -5,18 +5,30 @@ GEOMETRY_COLOR_RUSTUP_nightly=${GEOMETRY_COLOR_RUSTUP_NIGHTLY:-red}
 
 # Symbol definitions
 GEOMETRY_SYMBOL_RUSTUP=${GEOMETRY_SYMBOL_RUSTUP:-"⚙"}
-GEOMETRY_SYMBOL_RUSTUP_SEPARATOR=${GEOMETRY_SYMBOL_RUSTUP_SEPARATOR:-"$GEOMETRY_GIT_SEPARATOR"}
 
-geometry_prompt_rustup_setup() {}
+geometry_prompt_rustup_setup() {
+    GEOMETRY_STARRED_RUSTUP=$1
+}
+
+_geometry_prompt_rustup_check() {
+    (( $+commands[rustup_prompt_helper] )) || return 1
+
+    [[ $GEOMETRY_STARRED_RUSTUP ]] && return 0
+
+    test -f Cargo.toml && return 0
+
+    _git_dir=`git rev-parse --git-dir 2>/dev/null`
+    test -f "${_git_dir}/../Cargo.toml" && return 0
+
+    return 1
+}
 
 geometry_prompt_rustup_render() {
-    if (( $+commands[rustup_prompt_helper] )); then
-        git rev-parse --git-dir > /dev/null 2>&1 || GEOMETRY_SYMBOL_RUSTUP_SEPARATOR=""
-        GEOMETRY_RUSTUP_TOOLCHAIN="$(rustup_prompt_helper 2> /dev/null)"
-        GEOMETRY_COLOR_RUSTUP=${(e)GEOMETRY_RUSTUP_TOOLCHAIN:+\$GEOMETRY_COLOR_RUSTUP_${GEOMETRY_RUSTUP_TOOLCHAIN}}
-        GEOMETRY_RUSTUP=$(prompt_geometry_colorize $GEOMETRY_COLOR_RUSTUP $GEOMETRY_SYMBOL_RUSTUP)
-        echo "$GEOMETRY_SYMBOL_RUSTUP_SEPARATOR $GEOMETRY_RUSTUP"
-    fi
+    _geometry_prompt_rustup_check || return
+
+    GEOMETRY_RUSTUP_TOOLCHAIN="$(rustup_prompt_helper 2> /dev/null)"
+    GEOMETRY_COLOR_RUSTUP=${(e)GEOMETRY_RUSTUP_TOOLCHAIN:+\$GEOMETRY_COLOR_RUSTUP_${GEOMETRY_RUSTUP_TOOLCHAIN}}
+    echo $(prompt_geometry_colorize $GEOMETRY_COLOR_RUSTUP $GEOMETRY_SYMBOL_RUSTUP)
 }
 
 geometry_plugin_register rustup


### PR DESCRIPTION
A star* can mean anything, usually 'always display this plugin'

It will be passed in as the first parameter to the setup()

I am open to other ideas, like

* always passing it in as the first arg to render()
* making it a different symbol than *, since that requires quoting
* creating a helper function to check if a plugin is starred