### PR TITLE
geometry/plugin: remove trailing plugin separator

### DIFF
--- a/lib/plugin.zsh
+++ b/lib/plugin.zsh
@@ -76,5 +76,5 @@ geometry_plugin_render() {
     fi
   done
 
-  echo "$rprompt"
+  echo "${rprompt:0:-${#GEOMETRY_PLUGIN_SEPARATOR}}"
 }


### PR DESCRIPTION
If you define a plugin separator, it always renders. This removes it from the end.