### PR TITLE
lib/plugin: support plugin pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ documentation and configuration for each specific plugin in the
 [plugins](/plugins) directory.
 
 Some plugins only render when you are in a given directory or in the presence of a given file.
-You can have those plugins always render by pinning a `+` before the name
+You can have those plugins always render by pinning a `+` before the name.
 
 ```sh
 export GEOMETRY_PROMPT_PLUGINS=(exec_time git +rustup) # rustup will always render

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ fast™.
 
 ## Plugins
 
-geometry has an internal plugin architecture. The default plugins are `exec_time`, `git` and `hg`. But you can enable a variety of built-in plugins just by setting the `GEOMETRY_PROMPT_PLUGINS` variable in your own configuration files:
+geometry has an internal plugin architecture. The default plugins are `exec_time`, `git` and `hg`.
+But you can enable a variety of built-in plugins just by setting the `GEOMETRY_PROMPT_PLUGINS` variable in your own configuration files:
 
 ```sh
 GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg)
@@ -74,6 +75,12 @@ GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg)
 These plugins will load and display on the right prompt. You can check the
 documentation and configuration for each specific plugin in the
 [plugins](/plugins) directory.
+
+You can pin* a plugin by appending `*` to the end of the name. Geometry will always render the plugin.
+
+```sh
+GEOMETRY_PROMPT_PLUGINS+=('rustup*')
+```
 
 geometry also supports your own custom plugins. See the plugin [documentation](/plugins/README.md) for
 instructions and examples.

--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ These plugins will load and display on the right prompt. You can check the
 documentation and configuration for each specific plugin in the
 [plugins](/plugins) directory.
 
-You can pin* a plugin by appending `*` to the end of the name. Geometry will always render the plugin.
+Some plugins only render when you are in a given directory or in the presence of a given file.
+You can have those plugins always render by pinning a `+` before the name
 
 ```sh
-GEOMETRY_PROMPT_PLUGINS+=('rustup*')
+export GEOMETRY_PROMPT_PLUGINS=(exec_time git +rustup) # rustup will always render
 ```
 
 geometry also supports your own custom plugins. See the plugin [documentation](/plugins/README.md) for

--- a/lib/plugin.zsh
+++ b/lib/plugin.zsh
@@ -10,9 +10,16 @@ fi
 # List of active plugins
 typeset -ga _GEOMETRY_PROMPT_PLUGINS
 
+# List of pinned plugins
+typeset -ga _GEOMETRY_PROMPT_PLUGINS_PINNED
+
 # Set up default plugins
 geometry_plugin_setup() {
   for plugin in $GEOMETRY_PROMPT_PLUGINS; do
+    if [[ $plugin[-1] == '*' ]]; then
+      plugin=${plugin%?}
+      _GEOMETRY_PROMPT_PLUGINS_PINNED+=$plugin
+    fi
     source "$GEOMETRY_ROOT/plugins/$plugin/plugin.zsh"
   done
 }
@@ -56,6 +63,10 @@ geometry_plugin_unregister() {
     geometry_prompt_${plugin}_shutdown
   fi
 
+  if [[ $_GEOMETRY_PROMPT_PLUGINS_PINNED[(r)$plugin] != "" ]]; then
+    _GEOMETRY_PROMPT_PLUGINS_PINNED[$_GEOMETRY_PROMPT_PLUGINS_PINNED[(i)$plugin]]=()
+  fi
+
   _GEOMETRY_PROMPT_PLUGINS[$_GEOMETRY_PROMPT_PLUGINS[(i)$plugin]]=()
 }
 
@@ -70,6 +81,10 @@ geometry_plugin_render() {
   local render=""
 
   for plugin in $_GEOMETRY_PROMPT_PLUGINS; do
+
+    pinned=$_GEOMETRY_PROMPT_PLUGINS_PINNED[(r)$plugin]
+    [ $pinned ] || geometry_prompt_${plugin}_check || continue
+
     render=$(geometry_prompt_${plugin}_render)
     if [[ -n $render ]]; then
       rprompt+="$render$GEOMETRY_PLUGIN_SEPARATOR"

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -23,10 +23,12 @@ configuration files.
 
 
 ```sh
-GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg 'rustup*')
+GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg +rustup)
 ```
 
 *Note: if you're not sure where to put geometry configs, just add them to your `.zshrc`*
+
+*Note: the `+` before rustup means the plugin is pinned, and will always render, regardless of context*
 
 ## Custom plugins
 
@@ -135,5 +137,5 @@ geometry_plugin_register pretty_git
 
 ## Pinning
 
-A user may decide to pin a plugin by appending a `*` after the plugin name.
-This means geometry will skip the `geometry_prompt_${plugin}_check()` function, and always render.
+A user may decide to pin a plugin by prepending a `+` before the plugin name.
+This means geometry will skip the `geometry_prompt_${plugin}_check()` function, and always run the `render` function.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -23,7 +23,7 @@ configuration files.
 
 
 ```sh
-GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg)
+GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg 'rustup*')
 ```
 
 *Note: if you're not sure where to put geometry configs, just add them to your `.zshrc`*
@@ -31,7 +31,7 @@ GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg)
 ## Custom plugins
 
 If you want to set up your own custom plugin, it's pretty straightforward to do
-so. All you need is a `setup` and a `render` function, with the plugin name on
+so. All you need is a `setup`, `check`, and a `render` function, with the plugin name on
 them.
 
 Let's assume you want to add a plugin that prints `(☞ﾟ∀ﾟ)☞` when the git branch
@@ -62,19 +62,25 @@ for now, so let's leave it blank.
 geometry_prompt_pretty_git_setup() {}
 ```
 
-Note that the `setup` and `render` functions must obey the naming convention of
+Note that the `setup`, `check` and `render` functions must obey the naming convention of
 `geometry_prompt_<plugin_name>_setup/render`.
+
+Now, checking. The `check` function is called before `render`, and should check if
+it makes sense to display the plugin in the current context, returning non-zero if
+we should skip rendering.
+
+```sh
+geometry_prompt_pretty_git_check() {
+  # Do nothing if we're not in a repository
+  [ -d $PWD/.git ] || return 1
+}
+```
 
 Now, rendering. The `render` function is the one that gets called to print to
 the `RPROMPT`. Let's simply check the branch status and print accordingly:
 
 ```sh
 geometry_prompt_pretty_git_render() {
-  # Do nothing if we're not in a repository
-  if [ ! -d $PWD/.git ]; then
-    return
-  fi
-
   if test -z "$(git status --porcelain --ignore-submodules)"; then
     echo $GEOMETRY_PRETTY_GIT_CLEAN
   else
@@ -109,12 +115,13 @@ GEOMETRY_PRETTY_GIT_DIRTY=${GEOMETRY_PRETTY_GIT_DIRTY:-"(ノಠ益ಠ)ノ彡┻�
 
 geometry_prompt_pretty_git_setup() {}
 
-geometry_prompt_pretty_git_render() {
+geometry_prompt_pretty_git_check() {
   # Do nothing if we're not in a repository
-  if [ ! -d $PWD/.git ]; then
-    return
-  fi
+  [ -d $PWD/.git ] || return 1
+}
 
+
+geometry_prompt_pretty_git_render() {
   if test -z "$(git status --porcelain --ignore-submodules)"; then
     echo $GEOMETRY_PRETTY_GIT_CLEAN
   else
@@ -125,3 +132,8 @@ geometry_prompt_pretty_git_render() {
 geometry_plugin_register pretty_git
 
 ```
+
+## Pinning
+
+A user may decide to pin a plugin by appending a `*` after the plugin name.
+This means geometry will skip the `geometry_prompt_${plugin}_check()` function, and always render.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -28,7 +28,7 @@ GEOMETRY_PROMPT_PLUGINS=(virtualenv docker_machine exec_time git hg +rustup)
 
 *Note: if you're not sure where to put geometry configs, just add them to your `.zshrc`*
 
-*Note: the `+` before rustup means the plugin is pinned, and will always render, regardless of context*
+*Note: the `+` before rustup means the plugin is [pinned](#Pinning), and will always render, regardless of context*
 
 ## Custom plugins
 

--- a/plugins/docker_machine/plugin.zsh
+++ b/plugins/docker_machine/plugin.zsh
@@ -6,11 +6,12 @@ GEOMETRY_SYMBOL_DOCKER_MACHINE=${GEOMETRY_SYMBOL_DOCKER_MACHINE:-"⚓"}
 
 geometry_prompt_docker_machine_setup() {}
 
+geometry_prompt_docker_machine_check() {
+  test -n $DOCKER_MACHINE_NAME || return 1
+}
+
 geometry_prompt_docker_machine_render() {
-    if test ! -z $DOCKER_MACHINE_NAME; then
-        ref=$DOCKER_MACHINE_NAME || return
-        echo "$(prompt_geometry_colorize $GEOMETRY_COLOR_DOCKER_MACHINE "(${GEOMETRY_SYMBOL_DOCKER_MACHINE} ${ref})")"
-    fi
+  echo "$(prompt_geometry_colorize $GEOMETRY_COLOR_DOCKER_MACHINE "(${GEOMETRY_SYMBOL_DOCKER_MACHINE} ${DOCKER_MACHINE_NAME})")"
 }
 
 # Self-register plugin

--- a/plugins/exec_time/plugin.zsh
+++ b/plugins/exec_time/plugin.zsh
@@ -37,6 +37,8 @@ geometry_prompt_exec_time_setup() {
   return true
 }
 
+geometry_prompt_exec_time_check() {}
+
 geometry_prompt_exec_time_render() {
   echo "$prompt_geometry_command_exec_time"
 }

--- a/plugins/git/plugin.zsh
+++ b/plugins/git/plugin.zsh
@@ -142,31 +142,34 @@ prompt_geometry_git_conflicts() {
 }
 
 geometry_prompt_git_setup() {
+  (( $+commands[git] )) || return 1
+}
+
+geometry_prompt_git_check() {
+  git rev-parse --git-dir > /dev/null 2>&1 || return 1
 }
 
 geometry_prompt_git_render() {
-  if git rev-parse --git-dir > /dev/null 2>&1; then
-    if $PROMPT_GEOMETRY_GIT_CONFLICTS ; then
-      conflicts="$(prompt_geometry_git_conflicts)"
-    fi
-
-    if $PROMPT_GEOMETRY_GIT_TIME; then
-      local git_time_since_commit=$(prompt_geometry_git_time_since_commit)
-      if [[ -n $git_time_since_commit ]]; then
-          time=" $git_time_since_commit $GEOMETRY_GIT_SEPARATOR"
-      fi
-    fi
-
-    local render="$(prompt_geometry_git_symbol)"
-
-    if [[ -n $render ]]; then
-      render+=" "
-    fi
-
-    render+="$(prompt_geometry_git_branch) ${conflicts}${GEOMETRY_GIT_SEPARATOR}${time} $(prompt_geometry_git_status)"
-
-    echo -n $render
+  if $PROMPT_GEOMETRY_GIT_CONFLICTS ; then
+    conflicts="$(prompt_geometry_git_conflicts)"
   fi
+
+  if $PROMPT_GEOMETRY_GIT_TIME; then
+    local git_time_since_commit=$(prompt_geometry_git_time_since_commit)
+    if [[ -n $git_time_since_commit ]]; then
+        time=" $git_time_since_commit $GEOMETRY_GIT_SEPARATOR"
+    fi
+  fi
+
+  local render="$(prompt_geometry_git_symbol)"
+
+  if [[ -n $render ]]; then
+    render+=" "
+  fi
+
+  render+="$(prompt_geometry_git_branch) ${conflicts}${GEOMETRY_GIT_SEPARATOR}${time} $(prompt_geometry_git_status)"
+
+  echo -n $render
 }
 
 # Self-register plugin

--- a/plugins/hg/plugin.zsh
+++ b/plugins/hg/plugin.zsh
@@ -24,13 +24,15 @@ geometry_prompt_hg_status() {
 }
 
 geometry_prompt_hg_setup() {
-  return $+commands['hg'];
+  (( $+commands['hg'] )) || return 1
+}
+
+geometry_prompt_hg_check() {
+  test -d .hg || return 1
 }
 
 geometry_prompt_hg_render() {
-  if [[ -d $PWD/.hg ]]; then
-    echo "$(geometry_prompt_hg_branch) ${GEOMETRY_SYMBOL_HG_SEPARATOR} $(geometry_prompt_hg_status)"
-  fi
+  echo "$(geometry_prompt_hg_branch) ${GEOMETRY_SYMBOL_HG_SEPARATOR} $(geometry_prompt_hg_status)"
 }
 
 geometry_plugin_register hg

--- a/plugins/node/plugin.zsh
+++ b/plugins/node/plugin.zsh
@@ -5,22 +5,20 @@ GEOMETRY_COLOR_PACKAGER_VERSION=${GEOMETRY_COLOR_PACKAGER_VERSION:-black}
 GEOMETRY_SYMBOL_PACKAGER_VERSION=${GEOMETRY_SYMBOL_PACKAGER_VERSION:-"⬡"}
 GEOMETRY_NODE_PACKAGER_VERSION=$(prompt_geometry_colorize $GEOMETRY_COLOR_PACKAGER_VERSION $GEOMETRY_SYMBOL_PACKAGER_VERSION) 
 
-geometry_prompt_node_setup() {}
+geometry_prompt_node_setup() {
+    (( $+commands[node] )) || (( $+commands[yarn] )) || return 1
+}
+
+geometry_prompt_node_check() {
+    test -f package.json || test -f yarn.lock || return 1
+}
 
 geometry_prompt_node_render() {
-    if [[ ! $+commands[node] ]]; then 
-        return
-    fi
-
-    if [[ ! -f "$PWD/package.json" ]]; then
-        return
-    fi
-
     local GEOMETRY_NODE_DEFAULT_PACKAGE_MANAGER=npm
 
-    if [[ $+commands[yarn] && -f "$PWD/yarn.lock" ]]; then
+    if [[ $+commands[yarn] && -f yarn.lock ]]; then
         GEOMETRY_NODE_DEFAULT_PACKAGE_MANAGER=yarn
-    fi 
+    fi
 
     GEOMETRY_PACKAGER_VERSION="$($GEOMETRY_NODE_DEFAULT_PACKAGE_MANAGER --version 2> /dev/null)" 
     GEOMETRY_NODE_VERSION="$(node -v 2> /dev/null)"

--- a/plugins/ruby/plugin.zsh
+++ b/plugins/ruby/plugin.zsh
@@ -8,9 +8,7 @@ GEOMETRY_SYMBOL_RUBY_RVM_VERSION=${GEOMETRY_SYMBOL_RUBY_RVM_VERSION:-"◆"}
 GEOMETRY_RUBY_RVM_VERSION=$(prompt_geometry_colorize $GEOMETRY_COLOR_RUBY_RVM_VERSION $GEOMETRY_SYMBOL_RUBY_RVM_VERSION) 
 
 prompt_geometry_get_full_ruby_version() {
-  if (( $+commands[ruby] )); then
-      GEOMETRY_RUBY_VERSION_FULL="$(ruby -v)"
-  fi
+  (( $+commands[ruby] )) && GEOMETRY_RUBY_VERSION_FULL="$(ruby -v)"
 }
 
 prompt_geometry_ruby_version() {
@@ -19,9 +17,7 @@ prompt_geometry_ruby_version() {
 }
 
 prompt_geometry_get_full_rvm_version() {
-  if (( $+commands[rvm] )); then
-      GEOMETRY_RVM_VERSION_FULL="$(rvm -v)"
-  fi
+  (( $+commands[rvm] )) && GEOMETRY_RVM_VERSION_FULL="$(rvm -v)"
 }
 
 prompt_geometry_rvm_version() {
@@ -29,7 +25,11 @@ prompt_geometry_rvm_version() {
   GEOMETRY_RVM_VERSION=$match[1]
 }
 
-geometry_prompt_ruby_setup() {}
+geometry_prompt_ruby_setup() {
+  (( $+commands[ruby] )) || return 1
+}
+
+geometry_prompt_ruby_check() {}
 
 prompt_geometry_current_rvm_gemset_name() {
   if $GEOMETRY_RUBY_RVM_SHOW_GEMSET; then
@@ -47,10 +47,6 @@ prompt_geometry_current_rvm_gemset_name() {
 }
 
 geometry_prompt_ruby_render() {
-  if (( ! $+commands[ruby] )); then
-      return "";
-  fi
-
   prompt_geometry_get_full_ruby_version
   prompt_geometry_ruby_version
 

--- a/plugins/rustup/README.md
+++ b/plugins/rustup/README.md
@@ -10,7 +10,7 @@ It requires [rustup_prompt_helper][].
 ## Configuration
 
 ```sh
-GEOMETRY_PROMPT_PLUGINS+=('rustup*')
+GEOMETRY_PROMPT_PLUGINS+=(rustup)
 ```
 
 ### Colors

--- a/plugins/rustup/README.md
+++ b/plugins/rustup/README.md
@@ -1,12 +1,17 @@
 # Rustup
 
-Rustup plugin. Displays rust toolchain. Requires rustup_prompt_helper
+Rustup plugin. Displays the currently selected rust toolchain when in a directory or git repository with Cargo.toml
+It requires [rustup_prompt_helper][].
 
 ## Installation
 
     cargo install rustup_prompt_helper
 
 ## Configuration
+
+```sh
+GEOMETRY_PROMPT_PLUGINS+=('rustup*')
+```
 
 ### Colors
 
@@ -16,9 +21,10 @@ GEOMETRY_COLOR_RUSTUP_BETA="yellow"
 GEOMETRY_COLOR_RUSTUP_NIGHTLY="red"
 ```
 
-
 ### Symbols
 
 ```sh
 GEOMETRY_SYMBOL_RUSTUP="⚙"
 ```
+
+[rustup_prompt_helper]: https://github.com/ijanos/rustup_prompt_helper

--- a/plugins/rustup/plugin.zsh
+++ b/plugins/rustup/plugin.zsh
@@ -5,18 +5,22 @@ GEOMETRY_COLOR_RUSTUP_nightly=${GEOMETRY_COLOR_RUSTUP_NIGHTLY:-red}
 
 # Symbol definitions
 GEOMETRY_SYMBOL_RUSTUP=${GEOMETRY_SYMBOL_RUSTUP:-"⚙"}
-GEOMETRY_SYMBOL_RUSTUP_SEPARATOR=${GEOMETRY_SYMBOL_RUSTUP_SEPARATOR:-"$GEOMETRY_GIT_SEPARATOR"}
 
-geometry_prompt_rustup_setup() {}
+geometry_prompt_rustup_setup() {
+  (( $+commands[rustup_prompt_helper] )) || return 1
+}
+
+geometry_prompt_rustup_check() {
+    test -f Cargo.toml && return 0
+     _git_dir=`git rev-parse --git-dir 2>/dev/null`
+    test -f "${_git_dir/\.git/Cargo.toml}" && return 0
+    return 1
+}
 
 geometry_prompt_rustup_render() {
-    if (( $+commands[rustup_prompt_helper] )); then
-        git rev-parse --git-dir > /dev/null 2>&1 || GEOMETRY_SYMBOL_RUSTUP_SEPARATOR=""
-        GEOMETRY_RUSTUP_TOOLCHAIN="$(rustup_prompt_helper 2> /dev/null)"
-        GEOMETRY_COLOR_RUSTUP=${(e)GEOMETRY_RUSTUP_TOOLCHAIN:+\$GEOMETRY_COLOR_RUSTUP_${GEOMETRY_RUSTUP_TOOLCHAIN}}
-        GEOMETRY_RUSTUP=$(prompt_geometry_colorize $GEOMETRY_COLOR_RUSTUP $GEOMETRY_SYMBOL_RUSTUP)
-        echo "$GEOMETRY_SYMBOL_RUSTUP_SEPARATOR $GEOMETRY_RUSTUP"
-    fi
+    GEOMETRY_RUSTUP_TOOLCHAIN="$(rustup_prompt_helper 2> /dev/null)"
+    GEOMETRY_COLOR_RUSTUP=${(e)GEOMETRY_RUSTUP_TOOLCHAIN:+\$GEOMETRY_COLOR_RUSTUP_${GEOMETRY_RUSTUP_TOOLCHAIN}}
+    echo $(prompt_geometry_colorize $GEOMETRY_COLOR_RUSTUP $GEOMETRY_SYMBOL_RUSTUP)
 }
 
 geometry_plugin_register rustup

--- a/plugins/virtualenv/plugin.zsh
+++ b/plugins/virtualenv/plugin.zsh
@@ -3,12 +3,13 @@ GEOMETRY_COLOR_VIRTUALENV=${GEOMETRY_COLOR_PROMPT:-green}
 
 geometry_prompt_virtualenv_setup() {}
 
+geometry_prompt_virtualenv_check() {
+  test -z $VIRTUAL_ENV || return 1
+}
+
 geometry_prompt_virtualenv_render() {
-  local ref
-  if test ! -z $VIRTUAL_ENV; then
-    ref=$(basename $VIRTUAL_ENV) || return
-    echo "$(prompt_geometry_colorize $GEOMETRY_COLOR_VIRTUALENV "(${ref})")"
-  fi
+  local ref=$(basename $VIRTUAL_ENV)
+  echo "$(prompt_geometry_colorize $GEOMETRY_COLOR_VIRTUALENV "(${ref})")"
 }
 
 # Self-register plugin


### PR DESCRIPTION
This adds geometry_prompt_plugin_check(), which will be run to determine if we are in a context where it makes sense to display the plugin

A plugin can be pinned by appending a * to skip this check.

How can we could remove the quoting requirement for pins?

    GEOMETRY_PROMPT_PLUGINS+=(rustup*)

instead of

    GEOMETRY_PROMPT_PLUGINS+=('rustup*')