### PR TITLE
Fix rprompt plugin separator rendering

### DIFF
--- a/lib/plugin.zsh
+++ b/lib/plugin.zsh
@@ -97,10 +97,8 @@ geometry_plugin_render() {
 
     render=$(geometry_prompt_${plugin}_render)
     if [[ -n $render ]]; then
+      [[ -n $rprompt ]] && rprompt+="$GEOMETRY_PLUGIN_SEPARATOR"
       rprompt+="$render"
-      if [[ $_GEOMETRY_PROMPT_PLUGINS[(i)$plugin] < $#_GEOMETRY_PROMPT_PLUGINS ]]; then
-        rprompt+="$GEOMETRY_PLUGIN_SEPARATOR"
-      fi
     fi
   done
 


### PR DESCRIPTION
This fixes a bug I had with trailing plugins whose check would fail