### PR TITLE
Moves the cleanup of the async tempfile from on-startup to on-exit

### DIFF
--- a/lib/async.zsh
+++ b/lib/async.zsh
@@ -23,12 +23,17 @@ typeset -g GEOMETRY_ASYNC_PROC_ID=0
     GEOMETRY_ASYNC_PROC_ID=$!
 }
 
-# Hooks precmd to run `-geometry_async_function` and hooks
-# `USR1` signal to comunicate with it
+# Removes the async temp file when zsh exits
+-geometry_async_zshexit() {
+    rm -f "${GEOMETRY_ASYNC_TMP_FULL_PATH}$$"
+}
+
+# geometry_async_setup adds zsh-hooks into precmd and zshexit, as well as a
+# signal trap on SIGUSR1, to support communication of asynchronous updates to
+# the running terminal.
 geometry_async_setup() {
     add-zsh-hook precmd '-geometry_async_precmd'
-
-    (\rm ${GEOMETRY_ASYNC_TMP_FULL_PATH}*) &> /dev/null
+    add-zsh-hook zshexit '-geometry_async_zshexit'
 
     TRAPUSR1() {
         # read from temp file

--- a/lib/async.zsh
+++ b/lib/async.zsh
@@ -25,7 +25,7 @@ typeset -g GEOMETRY_ASYNC_PROC_ID=0
 
 # Removes the async temp file when zsh exits
 -geometry_async_zshexit() {
-    rm -f "${GEOMETRY_ASYNC_TMP_FULL_PATH}$$"
+    \rm -f "${GEOMETRY_ASYNC_TMP_FULL_PATH}$$"
 }
 
 # geometry_async_setup adds zsh-hooks into precmd and zshexit, as well as a


### PR DESCRIPTION
The core issue in #114 is that if `rm` hits a file it couldn't delete (generally due to some form of  permission issues), it will prompt the user.

Where this generally helpful behavior becomes problematic is when async updates are enabled. `geometry_async_setup` currently attempts to clean up any old or leaked async temp files by running `rm` on them at startup. When the prompt triggers it ends up blocking the startup of the zsh shell since `geometry_async_setup` is in the hotpath for shell startup.

There were three options discussed for fixing this:
* Add the UID to tempfile prefix so the startup cleanup could avoid the discovered cause of permission issues (sudoed shells creating root owned files that the normal user can't delete)
* Make the deletion forceful, this will prevent `rm` from prompting
* Add an on-exit hook that will clean up the specific tempfile used by that zsh process

This PR implements the 3rd option.

(Fixes #114)