### PR TITLE
Initial background-jobs plugin implementation

### DIFF
--- a/lib/plugin.zsh
+++ b/lib/plugin.zsh
@@ -4,7 +4,7 @@ typeset -g GEOMETRY_PLUGIN_SEPARATOR=${GEOMETRY_PLUGIN_SEPARATOR:-" "}
 # Define default plugins
 typeset -ga GEOMETRY_PROMPT_PLUGINS
 if [[ $#GEOMETRY_PROMPT_PLUGINS -eq 0 ]]; then
-  GEOMETRY_PROMPT_PLUGINS=(exec_time git hg)
+  GEOMETRY_PROMPT_PLUGINS=(exec_time jobs git hg)
 fi
 
 # List of active plugins

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -14,11 +14,12 @@ Available plugins:
 * [Ruby](/plugins/ruby)
 * [Rustup](/plugins/rustup)
 * [Virtualenv](/plugins/virtualenv)
+* [Background jobs](/plugins/jobs)
 
 ## Default plugins
 
-By default, geometry uses `exec_time`, `git` and `hg`. You can configure a different
-setup by changing the `GEOMETRY_PROMPT_PLUGINS` variable in your own
+By default, geometry uses `exec_time`, `jobs`, `git` and `hg`. You can configure
+a different setup by changing the `GEOMETRY_PROMPT_PLUGINS` variable in your own
 configuration files.
 
 

--- a/plugins/jobs/README.md
+++ b/plugins/jobs/README.md
@@ -2,7 +2,13 @@
 
 Small plugin to display background jobs count.
 
-## Configuration
+## Customization
 
-None available.
+### Colors
+
+You can change the color by setting the `GEOMETRY_COLOR_JOBS` environment variable. Defaults to `blue`.
+
+### Symbols
+
+You can change the symbol by setting the `GEOMETRY_SYMBOL_JOBS` environment variable. Defaults to `⚙`.
 

--- a/plugins/jobs/README.md
+++ b/plugins/jobs/README.md
@@ -1,0 +1,8 @@
+# Background jobs
+
+Small plugin to display background jobs count.
+
+## Configuration
+
+None available.
+

--- a/plugins/jobs/plugin.zsh
+++ b/plugins/jobs/plugin.zsh
@@ -11,7 +11,8 @@ geometry_prompt_jobs_check() {
 }
 
 geometry_prompt_jobs_render() {
-  echo $(prompt_geometry_colorize $GEOMETRY_COLOR_JOBS '%(1j.${GEOMETRY_SYMBOL_JOBS} %j.)')
+  local jobs_prompt='%(1j.'$GEOMETRY_SYMBOL_JOBS' %j.)'
+  echo $(prompt_geometry_colorize $GEOMETRY_COLOR_JOBS $jobs_prompt)
 }
 
 geometry_plugin_register jobs

--- a/plugins/jobs/plugin.zsh
+++ b/plugins/jobs/plugin.zsh
@@ -4,7 +4,9 @@ GEOMETRY_COLOR_JOBS=${GEOMETRY_COLOR_JOBS:-blue}
 # Symbol definitions
 GEOMETRY_SYMBOL_JOBS=${GEOMETRY_SYMBOL_JOBS:-"⚙"}
 
-geometry_prompt_jobs_setup() {
+geometry_prompt_jobs_setup() {}
+
+geometry_prompt_jobs_check() {
   [[ $(print -P '%j') == "0" ]]
 }
 

--- a/plugins/jobs/plugin.zsh
+++ b/plugins/jobs/plugin.zsh
@@ -1,13 +1,15 @@
-geometry_prompt_jobs_setup() {
-  return true
-}
+# Color definitions
+GEOMETRY_COLOR_JOBS=${GEOMETRY_COLOR_JOBS:-blue}
 
-geometry_prompt_jobs_check() {
-  return true
+# Symbol definitions
+GEOMETRY_SYMBOL_JOBS=${GEOMETRY_SYMBOL_JOBS:-"⚙"}
+
+geometry_prompt_jobs_setup() {
+  [[ $(print -P '%j') == "0" ]]
 }
 
 geometry_prompt_jobs_render() {
-  echo '%(1j.[%j].)'
+  echo $(prompt_geometry_colorize $GEOMETRY_COLOR_JOBS '%(1j.${GEOMETRY_SYMBOL_JOBS} %j.)')
 }
 
 geometry_plugin_register jobs

--- a/plugins/jobs/plugin.zsh
+++ b/plugins/jobs/plugin.zsh
@@ -1,0 +1,14 @@
+geometry_prompt_jobs_setup() {
+  return true
+}
+
+geometry_prompt_jobs_check() {
+  return true
+}
+
+geometry_prompt_jobs_render() {
+  echo '%(1j.[%j].)'
+}
+
+geometry_plugin_register jobs
+


### PR DESCRIPTION
Bare bones background-jobs plugin. No icon, color or configuration available. All suggestions welcome.

It will display as follows if there is one or more background jobs:

![screenshot from 2017-03-15 22-54-10](https://cloud.githubusercontent.com/assets/1857707/23978349/3c3217e0-09fc-11e7-96a8-9921b82e5eba.png)


It won't display anything if there is no background job.

Fixes #110 