### PR TITLE
Fix malicious branch name shell injection

### DIFF
--- a/plugins/git/plugin.zsh
+++ b/plugins/git/plugin.zsh
@@ -54,7 +54,7 @@ prompt_geometry_git_time_since_commit() {
 prompt_geometry_git_branch() {
   ref=$(git symbolic-ref --short HEAD 2> /dev/null) || \
   ref=$(git rev-parse --short HEAD 2> /dev/null) || return
-  echo "$(prompt_geometry_colorize $GEOMETRY_COLOR_GIT_BRANCH $ref)"
+  echo "$(prompt_geometry_colorize $GEOMETRY_COLOR_GIT_BRANCH ${ref/\$/\\$})"
 }
 
 prompt_geometry_git_status() {

--- a/plugins/virtualenv/plugin.zsh
+++ b/plugins/virtualenv/plugin.zsh
@@ -9,7 +9,7 @@ geometry_prompt_virtualenv_check() {
 
 geometry_prompt_virtualenv_render() {
   local ref=$(basename $VIRTUAL_ENV)
-  echo "$(prompt_geometry_colorize $GEOMETRY_COLOR_VIRTUALENV "(${ref})")"
+  echo "$(prompt_geometry_colorize $GEOMETRY_COLOR_VIRTUALENV "(${ref/\$/\\$/})")"
 }
 
 # Self-register plugin


### PR DESCRIPTION
Described in https://github.com/njhartwell/pw3nage

If a branch name has something like `$(./pw3nage)`
we would execute it. Now we escape the $ symbol.

Fixes #137 