### PR TITLE
Fix git branch expansion

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -78,6 +78,7 @@ prompt_geometry_render() {
         # comes with newer git info
         RPROMPT=""
     else
+        setopt localoptions no_prompt_subst
         RPROMPT="$(prompt_geometry_render_rprompt)"
     fi
   fi

--- a/lib/async.zsh
+++ b/lib/async.zsh
@@ -37,6 +37,7 @@ geometry_async_setup() {
 
     TRAPUSR1() {
         # read from temp file
+        setopt no_prompt_subst
         RPROMPT="$(<${GEOMETRY_ASYNC_TMP_FULL_PATH}$$)"
 
         # reset proc number

--- a/lib/async.zsh
+++ b/lib/async.zsh
@@ -37,7 +37,7 @@ geometry_async_setup() {
 
     TRAPUSR1() {
         # read from temp file
-        setopt no_prompt_subst
+        setopt localoptions no_prompt_subst
         RPROMPT="$(<${GEOMETRY_ASYNC_TMP_FULL_PATH}$$)"
 
         # reset proc number


### PR DESCRIPTION
Handled a basic test case:


    $ git init
    $ git branch '$(ls)'

Shown as:

    $(ls) :: no commits :: ⬢ :: ar :: 0 files, 0
    

Fixes #137 