### PR TITLE
Fix prompt_subst option set global

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -42,7 +42,7 @@ prompt_geometry_set_cmd_title() {
   local CURR_DIR="${PWD##*/}"
   setopt localoptions no_prompt_subst
   print -n '\e]0;'
-  print -Pn '$COMMAND @ $CURR_DIR'
+  print -rn "$COMMAND @ $CURR_DIR"
   print -n '\a'
 }
 

--- a/geometry.zsh
+++ b/geometry.zsh
@@ -40,6 +40,7 @@ GEOMETRY_PROMPT_SUFFIX=${GEOMETRY_PROMPT_SUFFIX:-''}
 prompt_geometry_set_cmd_title() {
   local COMMAND="${2}"
   local CURR_DIR="${PWD##*/}"
+  setopt localoptions prompt_subst
   print -n '\e]0;'
   print -Pn '$COMMAND @ $CURR_DIR'
   print -n '\a'
@@ -47,6 +48,7 @@ prompt_geometry_set_cmd_title() {
 
 # Prevent command showing on title after ending
 prompt_geometry_set_title() {
+  setopt localoptions prompt_subst
   print -n '\e]0;'
   print -Pn '%~'
   print -n '\a'
@@ -85,7 +87,6 @@ prompt_geometry_render() {
 }
 
 prompt_geometry_setup() {
-  setopt PROMPT_SUBST
   zmodload zsh/datetime
   autoload -U add-zsh-hook
   if $PROMPT_GEOMETRY_ENABLE_PLUGINS; then

--- a/geometry.zsh
+++ b/geometry.zsh
@@ -40,7 +40,7 @@ GEOMETRY_PROMPT_SUFFIX=${GEOMETRY_PROMPT_SUFFIX:-''}
 prompt_geometry_set_cmd_title() {
   local COMMAND="${2}"
   local CURR_DIR="${PWD##*/}"
-  setopt localoptions prompt_subst
+  setopt localoptions no_prompt_subst
   print -n '\e]0;'
   print -Pn '$COMMAND @ $CURR_DIR'
   print -n '\a'
@@ -48,7 +48,6 @@ prompt_geometry_set_cmd_title() {
 
 # Prevent command showing on title after ending
 prompt_geometry_set_title() {
-  setopt localoptions prompt_subst
   print -n '\e]0;'
   print -Pn '%~'
   print -n '\a'


### PR DESCRIPTION
This was introduced in https://github.com/frmendes/geometry/pull/74.

Test case:

     ▲ ~ printf -f "%s" a
    27m" a @ usera%

Expected behavior:

     ▲ ~ printf -f "%s" a
     a
    
Removing prompt_subst option breaks `set_cmd_title`.

Edit: Update regression link.