### PR TITLE
zsh-async worker missing env variables

### DIFF
--- a/lib/async.zsh
+++ b/lib/async.zsh
@@ -5,6 +5,9 @@ source $GEOMETRY_ROOT/lib/zsh-async/async.zsh 2> /dev/null
     local job="$1" code="$2" output="$3" exec_time="$4" stderr="$5"
     RPROMPT="${(j/::/)output}"
     zle && zle reset-prompt
+
+    # Explicitely stop async worker
+    async_stop_worker geometry_async_worker
 }
 
 # Wrapper to call rprompt renderer, needed to set up workers status

--- a/lib/async.zsh
+++ b/lib/async.zsh
@@ -18,6 +18,10 @@ source $GEOMETRY_ROOT/lib/zsh-async/async.zsh 2> /dev/null
 # Flushed currently running async jobs and queues a new one
 # See https://github.com/mafredri/zsh-async#async_flush_jobs-worker_name
 -geometry-async-job() {
+    # See https://github.com/mafredri/zsh-async#async_start_worker-worker_name--u--n--p-pid
+    async_start_worker geometry_async_worker -u -n # unique, notify through SIGWINCH
+    async_register_callback geometry_async_worker -geometry-async-callback
+
     async_flush_jobs geometry_async_worker 
     async_job geometry_async_worker -geometry-async-prompt $PWD
 }
@@ -33,9 +37,6 @@ geometry_async_setup() {
     fi
 
     async_init
-    # See https://github.com/mafredri/zsh-async#async_start_worker-worker_name--u--n--p-pid
-    async_start_worker geometry_async_worker -u -n # unique, notify through SIGWINCH
-    async_register_callback geometry_async_worker -geometry-async-callback
 
     # Submit a new job every precmd
     add-zsh-hook precmd -geometry-async-job


### PR DESCRIPTION
There was an issue with the zsh-async implementation which prevented registering custom plugins (see https://github.com/desyncr/geometry-dir-info-prompt/issues/4#issuecomment-302928204).

The issue was that we were creating a worker on the setup phase to submit jobs. The worker environment later on will not reflect the current geometry configuration (plugins etc).

This changeset moved zsh-async worker creation to every render cycle.