### PR TITLE
Add a note about setting var. when using antigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ geometry was built with easy configuration in mind. The best way to do so is by
 [using environment variables](https://github.com/frmendes/dotfiles/blob/7f448626e1c6e9c0ab7b474c5ff2c1939b64b7d2/system/prompt.zsh#L18-L24).
 
 Pretty much everything in geometry can be changed by setting a variable **before
-you load the theme**.
+you load the theme**. Note that if you use antigen, you must set them before sourcing `antigen.zsh`.
 
 The default options try to balance the theme in order to be both lightweight and contain useful features.
 


### PR DESCRIPTION
Hi,

Something like:

```sh
. /usr/share/zsh-antigen/antigen.zsh

GEOMETRY_SYMBOL_PROMPT="λ"

antigen use oh-my-zsh
antigen theme frmendes/geometry
```

won't work. But:

```sh
GEOMETRY_SYMBOL_PROMPT="λ"

. /usr/share/zsh-antigen/antigen.zsh

antigen use oh-my-zsh
antigen theme frmendes/geometry
```

is ok. So, I just added a note about it.