### PR TITLE
Add file/conflict indicators

### DIFF
--- a/plugins/git/plugin.zsh
+++ b/plugins/git/plugin.zsh
@@ -136,7 +136,7 @@ prompt_geometry_git_conflicts() {
       text=$GEOMETRY_SYMBOL_GIT_CONFLICTS_SOLVED
       color=$GEOMETRY_COLOR_GIT_CONFLICTS_SOLVED
     else
-      text="$GEOMETRY_SYMBOL_GIT_CONFLICTS_UNSOLVED ($file_count|$total)"
+      text="$GEOMETRY_SYMBOL_GIT_CONFLICTS_UNSOLVED (${file_count}f|${total}c)"
       color=$GEOMETRY_COLOR_GIT_CONFLICTS_UNSOLVED
     fi
 


### PR DESCRIPTION
I used to get confused a lot regarding which number was the file count and which number was the total conflict count.

I decided to add two indicators `f` for `files` and `c` for `conflicts`.

Preview here:

![screen shot 2017-08-09 at 17 50 56](https://user-images.githubusercontent.com/4325027/29133548-bda7dccc-7d2b-11e7-834f-e6571618cefc.png)

I'm was thinking about extracting the `f/c` indicator into variables but it's something so small and nitpicky that I'm not sure I should do it. Thoughts on that?