### PR TITLE
geometry/plugin: add kubectl context/namespace

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -10,6 +10,7 @@ Available plugins:
 * [Exec Time](/plugins/exec_time)
 * [Git](/plugins/git)
 * [Hg](/plugins/hg)
+* [Kube](/plugins/kube)
 * [Node](/plugins/node)
 * [Ruby](/plugins/ruby)
 * [Rustup](/plugins/rustup)

--- a/plugins/kube/README.md
+++ b/plugins/kube/README.md
@@ -1,0 +1,19 @@
+# Kube
+
+Kube plugin. Displays kubectl client version and current context/namespace. If you want it to display regardless of context use [plugin pinning](https://github.com/geometry-zsh/geometry/tree/master/plugins#pinning).
+
+## Configuration
+
+### Colors
+
+```sh
+GEOMETRY_COLOR_KUBE="blue"
+```
+
+
+### Symbols
+
+```sh
+GEOMETRY_SYMBOL_KUBE:-"⎈"
+```
+

--- a/plugins/kube/plugin.zsh
+++ b/plugins/kube/plugin.zsh
@@ -1,0 +1,41 @@
+# Color definitions
+GEOMETRY_COLOR_KUBE=${GEOMETRY_COLOR_KUBE:-blue}
+
+# Symbol definitions
+GEOMETRY_SYMBOL_KUBE=${GEOMETRY_SYMBOL_KUBE:-"⎈"}
+GEOMETRY_KUBE=$(prompt_geometry_colorize $GEOMETRY_COLOR_KUBE $GEOMETRY_SYMBOL_KUBE)
+
+prompt_geometry_get_full_kubectl_version() {
+  (( $+commands[kubectl] )) && GEOMETRY_KUBECTL_VERSION_FULL="$(kubectl version --client --short)"
+}
+
+prompt_geometry_kubectl_version() {
+  [[ $GEOMETRY_KUBECTL_VERSION_FULL =~ 'Client Version: ([0-9a-zA-Z.]+)' ]]
+  GEOMETRY_KUBECTL_VERSION=$match[1]
+}
+
+prompt_geometry_kube_config() {
+  GEOMETRY_KUBECTL_CONTEXT="$(kubectl config current-context 2> /dev/null)"
+  GEOMETRY_KUBECTL_NAMESPACE="$(kubectl config view -o "jsonpath={.contexts[?(@.name==\"$GEOMETRY_KUBECTL_CONTEXT\")].context.namespace}" 2> /dev/null)"
+}
+
+geometry_prompt_kube_setup() {
+    (( $+commands[kubectl] )) || return 1
+}
+
+geometry_prompt_kube_check() {
+    (( $+commands[kubectl] )) && test -f ~/.kube/config || return 1
+}
+
+geometry_prompt_kube_render() {
+    prompt_geometry_get_full_kubectl_version
+    prompt_geometry_kubectl_version
+    prompt_geometry_kube_config
+
+    if [[ -z $GEOMETRY_KUBECTL_NAMESPACE  ]]; then
+      GEOMETRY_KUBECTL_NAMESPACE=default
+    fi
+
+    echo "$GEOMETRY_KUBE $GEOMETRY_KUBECTL_VERSION ($GEOMETRY_KUBECTL_CONTEXT:$GEOMETRY_KUBECTL_NAMESPACE)"
+}
+


### PR DESCRIPTION
plugin shows kubectl client version and current context/namespace

<img width="231" alt="screen shot 2018-05-26 at 2 26 19 pm" src="https://user-images.githubusercontent.com/18538628/40573786-df846b90-60f0-11e8-9b03-c092611f0122.png">