### PR TITLE
Move to a function override approach

### DIFF
--- a/plugins/git/plugin.zsh
+++ b/plugins/git/plugin.zsh
@@ -166,27 +166,31 @@ geometry_prompt_git_render() {
   fi
 
   if $PROMPT_GEOMETRY_GIT_CONFLICTS ; then
-    conflicts="$(prompt_geometry_git_conflicts)"
+    export var_geometry_git_conflicts="$(prompt_geometry_git_conflicts)"
   fi
 
   if $PROMPT_GEOMETRY_GIT_TIME; then
     local git_time_since_commit=$(prompt_geometry_git_time_since_commit)
     if [[ -n $git_time_since_commit ]]; then
-        time=" $git_time_since_commit $GEOMETRY_GIT_SEPARATOR"
+        export var_geometry_git_time=" $git_time_since_commit $GEOMETRY_GIT_SEPARATOR"
     fi
   fi
 
   if $PROMPT_GEOMETRY_GIT_SHOW_STASHES && git rev-parse --quiet --verify refs/stash >/dev/null; then
-      stashes=" $GEOMETRY_GIT_STASHES $GEOMETRY_GIT_SEPARATOR";
+      var_geometry_git_stashes=" $GEOMETRY_GIT_STASHES $GEOMETRY_GIT_SEPARATOR";
   fi
 
-  local render="$(prompt_geometry_git_symbol)"
+  if typeset -f geometry_prompt_git_render_override > /dev/null; then
+    echo "$(geometry_prompt_git_render_override)"
+  else
+    local render="$(prompt_geometry_git_symbol)"
 
-  if [[ -n $render ]]; then
-    render+=" "
+    if [[ -n $render ]]; then
+      render+=" "
+    fi
+
+    render+="$(prompt_geometry_git_branch) ${var_geometry_git_conflicts}${GEOMETRY_GIT_SEPARATOR}${var_geometry_git_time}${var_geometry_git_stashes} $(prompt_geometry_git_status)"
+
+    echo -n $render
   fi
-
-  render+="$(prompt_geometry_git_branch) ${conflicts}${GEOMETRY_GIT_SEPARATOR}${time}${stashes} $(prompt_geometry_git_status)"
-
-  echo -n $render
 }

--- a/plugins/path/plugin.zsh
+++ b/plugins/path/plugin.zsh
@@ -72,7 +72,7 @@ geometry_prompt_path_render() {
     dir=$(basename $PWD)
   fi
 
-  export geometry_prompt_prefix="$GEOMETRY_PROMPT_PREFIX$GEOMETRY_PROMPT_PREFIX_SPACER"
+  export var_geometry_prompt_prefix="$GEOMETRY_PROMPT_PREFIX$GEOMETRY_PROMPT_PREFIX_SPACER"
 
   # Getting the correct symbol width is not as simple as getting the variable length
   # There are zero width characters that should not be accounted for.
@@ -84,13 +84,13 @@ geometry_prompt_path_render() {
   # (which we calculate in the symbol_width) and in the number of columns they
   # occupy on screen. See: https://github.com/geometry-zsh/geometry/issues/3
   local symbol_width="${#${(S%%)prompt_symbol//(\%([KF1]|)\{*\}|\%[Bbkf])}}"
-  export geometry_colorized_prompt_symbol="%$symbol_width{%(?.$GEOMETRY_PROMPT.$GEOMETRY_EXIT_VALUE)%}$GEOMETRY_SYMBOL_SPACER"
+  export var_geometry_colorized_prompt_symbol="%$symbol_width{%(?.$GEOMETRY_PROMPT.$GEOMETRY_EXIT_VALUE)%}$GEOMETRY_SYMBOL_SPACER"
 
-  export geometry_colorized_prompt_dir="%F{$GEOMETRY_COLOR_DIR}$dir%f$GEOMETRY_DIR_SPACER"
+  export var_geometry_colorized_prompt_dir="%F{$GEOMETRY_COLOR_DIR}$dir%f$GEOMETRY_DIR_SPACER"
 
   if typeset -f geometry_prompt_path_render_override > /dev/null; then
     echo "$(geometry_prompt_path_render_override)"
   else
-    echo "$geometry_prompt_prefix$geometry_colorized_prompt_symbol$geometry_colorized_prompt_dir$GEOMETRY_PROMPT_SUFFIX"
+    echo "$var_geometry_prompt_prefix$var_geometry_colorized_prompt_symbol$var_geometry_colorized_prompt_dir$GEOMETRY_PROMPT_SUFFIX"
   fi
 }

--- a/plugins/path/plugin.zsh
+++ b/plugins/path/plugin.zsh
@@ -72,7 +72,7 @@ geometry_prompt_path_render() {
     dir=$(basename $PWD)
   fi
 
-  local prompt_prefix="$GEOMETRY_PROMPT_PREFIX$GEOMETRY_PROMPT_PREFIX_SPACER"
+  export geometry_prompt_prefix="$GEOMETRY_PROMPT_PREFIX$GEOMETRY_PROMPT_PREFIX_SPACER"
 
   # Getting the correct symbol width is not as simple as getting the variable length
   # There are zero width characters that should not be accounted for.
@@ -84,9 +84,13 @@ geometry_prompt_path_render() {
   # (which we calculate in the symbol_width) and in the number of columns they
   # occupy on screen. See: https://github.com/geometry-zsh/geometry/issues/3
   local symbol_width="${#${(S%%)prompt_symbol//(\%([KF1]|)\{*\}|\%[Bbkf])}}"
-  local colorized_prompt_symbol="%$symbol_width{%(?.$GEOMETRY_PROMPT.$GEOMETRY_EXIT_VALUE)%}$GEOMETRY_SYMBOL_SPACER"
+  export geometry_colorized_prompt_symbol="%$symbol_width{%(?.$GEOMETRY_PROMPT.$GEOMETRY_EXIT_VALUE)%}$GEOMETRY_SYMBOL_SPACER"
 
-  local colorized_prompt_dir="%F{$GEOMETRY_COLOR_DIR}$dir%f$GEOMETRY_DIR_SPACER"
+  export geometry_colorized_prompt_dir="%F{$GEOMETRY_COLOR_DIR}$dir%f$GEOMETRY_DIR_SPACER"
 
-  echo "$prompt_prefix$colorized_prompt_symbol$colorized_prompt_dir$GEOMETRY_PROMPT_SUFFIX"
+  if typeset -f geometry_prompt_path_render_override > /dev/null; then
+    echo "$(geometry_prompt_path_render_override)"
+  else
+    echo "$geometry_prompt_prefix$geometry_colorized_prompt_symbol$geometry_colorized_prompt_dir$GEOMETRY_PROMPT_SUFFIX"
+  fi
 }


### PR DESCRIPTION
Currently we are using variables to override values.

Variables aren't very flexible. This is making the codebase hard to read
to read and maintain.

This is a proposal commit to move to a function override based approach. If accepted, I can change other plugins to do the same.

This approach would allow users to better configure their prompts and
plugins without having to fork and change the source code. It would also remove the need for variables that represent personal taste, like prompt prefixes and suffixes.

Example:

![screen shot 2018-09-21 at 14 04 41](https://user-images.githubusercontent.com/4325027/45882887-6666c780-bda7-11e8-82de-89b741652049.png)

Before `reload` I simply uncommented the override function. Dotfiles:

```zsh
geometry_prompt_path_render_override() {
  echo " \n$geometry_colorized_prompt_dir $geometry_colorized_prompt_symbol"
}

GEOMETRY_COLOR_GIT_DIRTY=9
GEOMETRY_COLOR_GIT_BRANCH=6
GEOMETRY_COLOR_EXIT_VALUE=9
GEOMETRY_COLOR_DIR=242
GEOMETRY_COLOR_PROMPT=2
GEOMETRY_SYMBOL_EXIT_VALUE="⇝"
GEOMETRY_SYMBOL_PROMPT="⇝"
GEOMETRY_PROMPT_PATH="%2~"
GEOMETRY_SYMBOL_GIT_DIRTY="●"
GEOMETRY_SYMBOL_GIT_CLEAN="●"
PROMPT_GEOMETRY_GIT_SHOW_STASHES=false
GEOMETRY_PROMPT_PLUGINS_PRIMARY=(path)
GEOMETRY_PROMPT_PLUGINS_SECONDARY=(git)
PROMPT_GEOMETRY_GIT_CONFLICTS=true

GEOMETRY_ENV="development"
source $HOME/Developer/geometry/$GEOMETRY_ENV/geometry.zsh
```