### PR TITLE
Plugin: Exit Status RPROMPT

### DIFF
--- a/plugins/exit_code/README.md
+++ b/plugins/exit_code/README.md
@@ -1,0 +1,11 @@
+# Exit Code
+
+The exit code plugin prints non-zero exit codes in the RPROMPT.
+
+## Configuration
+
+```sh
+GEOMETRY_EXIT_CODE_SEPARATOR=":( "            # The separator to use.
+GEOMETRY_COLOR_EXIT_CODE=magenta              # The color of the exit code.
+```
+

--- a/plugins/exit_code/plugin.zsh
+++ b/plugins/exit_code/plugin.zsh
@@ -1,0 +1,20 @@
+GEOMETRY_COLOR_EXIT_CODE=${GEOMETRY_COLOR_EXIT_CODE:-magenta}
+GEOMETRY_EXIT_CODE_SEPARATOR=${GEOMETRY_EXIT_CODE_SEPARATOR:-":( "}
+
+local RETCODE=0
+
+get_exit_code() {
+    RETCODE=$?
+}
+
+geometry_prompt_exit_code_setup() {
+    add-zsh-hook precmd get_exit_code
+}
+
+geometry_prompt_exit_code_check() {
+    [[ $RETCODE != 0 ]]
+}
+
+geometry_prompt_exit_code_render() {
+    echo $(prompt_geometry_colorize $GEOMETRY_COLOR_EXIT_CODE "$GEOMETRY_EXIT_CODE_SEPARATOR$RETCODE")
+}


### PR DESCRIPTION
I couldn't find a clean and modular way to add the exit status to the RPROMPT so I put this quick module together. I'm submitting a PR in case other people could benefit from it.

Currently it only supports one color but it would be easy to add a success color as well for `+exit_status` setups.

Cheers,
Alex