### PR TITLE
Enable use of kube-ps1 instead of kube plugin

### DIFF
--- a/plugins/kube_ps1/README.md
+++ b/plugins/kube_ps1/README.md
@@ -1,0 +1,34 @@
+# kube_ps1
+
+kube_ps1 plugin based on project [kube-ps1](https://github.com/jonmosco/kube-ps1) that displays the current kubernetes and namespace on your Zsh right prompt.
+
+## Installation
+
+This plugin assumes you have the following installed:
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
+- [kube-ps1](https://github.com/jonmosco/kube-ps1)
+
+## Configuration
+
+In your ~/.zshrc, enable kube-ps1 plugin:
+
+```bash
+plugins=(
+    kube-ps1
+)
+```
+
+In your ~/.zshrc, enable geometry pompt kube_ps1 plugin:
+
+```bash
+GEOMETRY_PROMPT_PLUGINS=(
+    kube_ps1
+)
+```
+
+## Customization
+
+To change behavior of the plugin see kube-ps1 documentation for overwritting variables:
+[kube-ps1 customization](https://github.com/jonmosco/kube-ps1#customization)
+

--- a/plugins/kube_ps1/plugin.zsh
+++ b/plugins/kube_ps1/plugin.zsh
@@ -1,0 +1,20 @@
+geometry_prompt_kube_ps1_setup() {}
+
+geometry_prompt_kube_ps1_check() {
+  if [[ -z "$KUBE_PS1_ENABLED" ]]; then
+		return 1
+	fi
+}
+
+geometry_prompt_kube_ps1_render() {
+  local render="$(prompt_geometry_git_symbol)"
+
+  if [[ -n $render ]]; then
+    render+=" "
+  fi
+
+  render+="$(kube_ps1) "
+
+  echo -n $render
+}
+


### PR DESCRIPTION
Enable use of [kube-ps1](https://github.com/jonmosco/kube-ps1) that behaves faster and better then geometry plugin
[kube](https://github.com/geometry-zsh/geometry/tree/master/plugins/kube)

This appends on the RPROMP of the PS1 the k8s context.