### PR TITLE
feat: Added `GEOMETRY_STATUS_SHOW_CODE` and configuration.

### DIFF
--- a/.github/workflows/lines-of-code.yml
+++ b/.github/workflows/lines-of-code.yml
@@ -1,0 +1,13 @@
+name: lines-of-code
+
+on: pull_request
+
+jobs:
+  count:
+    steps:
+    - uses: actions/checkout@v1
+    - name: count with tokei
+      uses: docker://mbologna/docker-tokei
+      with:
+        entrypoint: tokei
+        args: -t=Zsh

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.3 - unreleased
+
+### Fixed
+- Accidental export of local fun variable
+
 ## 2.0.2 - 2019-09-04
 
 ### Fixed

--- a/functions/geometry_exitcode.zsh
+++ b/functions/geometry_exitcode.zsh
@@ -1,0 +1,6 @@
+# geometry_status - show a symbol with error/success and root/non-root information
+
+geometry_exitcode() {
+  : ${GEOMETRY_EXITCODE_COLOR:=red} 
+    (( $GEOMETRY_LAST_STATUS )) && ansi $GEOMETRY_EXITCODE_COLOR $GEOMETRY_LAST_STATUS
+}

--- a/functions/geometry_git.zsh
+++ b/functions/geometry_git.zsh
@@ -29,8 +29,8 @@ geometry_git_status() {
 
   [[ -z "$(git status --porcelain --ignore-submodules HEAD)" ]] \
   && [[ -z "$(git ls-files --others --modified --exclude-standard $(git rev-parse --show-toplevel))" ]] \
-  && ansi ${GEOMETRY_GIT_COLOR_DIRTY:-red} ${GEOMETRY_GIT_SYMBOL_DIRTY:-"⬡"} \
-  || ansi ${GEOMETRY_GIT_COLOR_CLEAN:-green} ${GEOMETRY_GIT_SYMBOL_CLEAN:-"⬢"}
+  && ansi ${GEOMETRY_GIT_COLOR_CLEAN:-green} ${GEOMETRY_GIT_SYMBOL_CLEAN:-"⬢"} \
+  || ansi ${GEOMETRY_GIT_COLOR_DIRTY:-red} ${GEOMETRY_GIT_SYMBOL_DIRTY:-"⬡"}
 }
 
 geometry_git_rebase() {

--- a/functions/geometry_git.zsh
+++ b/functions/geometry_git.zsh
@@ -1,7 +1,5 @@
 # geometry_git - please see the readme for documentation on all features
 
-(( $+commands[git] )) || return
-
 geometry_git_stashes() {
   git rev-parse --quiet --verify refs/stash >/dev/null \
     && ansi ${GEOMETRY_GIT_COLOR_STASHES:="144"} ${GEOMETRY_GIT_SYMBOL_STASHES:="●"}
@@ -87,6 +85,8 @@ geometry_git_conflicts() {
 }
 
 geometry_git() {
+  (( $+commands[git] )) || return
+
   command git rev-parse --git-dir > /dev/null 2>&1 || return
 
   $(command git rev-parse --is-bare-repository 2>/dev/null) \

--- a/functions/geometry_kube.zsh
+++ b/functions/geometry_kube.zsh
@@ -1,8 +1,7 @@
 # geometry_kube - show kubectl client version and current context/namespace.
 
-(( $+commands[kubectl] )) || return
-
 geometry_kube() {
+  (( $+commands[kubectl] )) || return
   ( ${GEOMETRY_KUBE_PIN:=false} ) || [[ -n "$KUBECONFIG" ]] || return
   : ${GEOMETRY_KUBE_SEPARATOR:="|"}
 

--- a/functions/geometry_kube.zsh
+++ b/functions/geometry_kube.zsh
@@ -1,31 +1,38 @@
 # geometry_kube - show kubectl client version and current context/namespace.
+geometry_kube_symbol() {
+  ansi ${GEOMETRY_KUBE_COLOR:=blue} ${GEOMETRY_KUBE_SYMBOL:="⎈"}
+}
+
+geometry_kube_namespace() {
+  local kube_namespace=$(kubectl config view --minify --output "jsonpath={..namespace}" 2> /dev/null)
+  ansi ${GEOMETRY_KUBE_NAMESPACE_COLOR:=default} ${kube_namespace:=default}
+}
+
+geometry_kube_context() {
+  local kube_context="$(kubectl config current-context 2> /dev/null)"
+  ansi ${GEOMETRY_KUBE_CONTEXT_COLOR:=default} ${kube_context}
+}
+
+geometry_kube_version() {
+  [[ $(kubectl version --client --short) =~ 'Client Version: ([0-9a-zA-Z.]+)' ]]
+  local kube_version=($match[1])
+  ansi ${GEOMETRY_KUBE_VERSION_COLOR:=default} ${kube_version:=default}
+}
 
 geometry_kube() {
   (( $+commands[kubectl] )) || return
-  ( ${GEOMETRY_KUBE_PIN:=false} ) || [[ -n "$KUBECONFIG" ]] || return
-  : ${GEOMETRY_KUBE_SEPARATOR:="|"}
 
-  # Variable declaration
-  local -a geometry_kube
-  local kube_symbol
-  local kube_context
-  local kube_namespace
-  local kube_version
+  ( ${GEOMETRY_KUBE_PIN:=true} ) || return
 
-  kube_symbol=$(ansi ${GEOMETRY_KUBE_COLOR:=blue} ${GEOMETRY_KUBE_SYMBOL:="⎈"})
+  ( ${GEOMETRY_KUBE_PIN:=false} ) || [[ -n "$KUBECONFIG" ]] || [[ -n "$(kubectl config current-context 2> /dev/null)" ]] || return
 
-  kube_context="$(kubectl config current-context 2> /dev/null)"
-  kube_context=$(ansi ${GEOMETRY_KUBE_CONTEXT_COLOR:=default} ${kube_context})
+  local geometry_kube_details && geometry_kube_details=(
+    $(geometry_kube_symbol)
+    $(geometry_kube_context)
+    $(geometry_kube_namespace)
+    $(geometry_kube_version)
+  )
 
-  kube_namespace=$(kubectl config view -o "jsonpath={.contexts[?(@.name==\"${kube_context}\")].context.namespace}" 2> /dev/null)
-  kube_namespace=$(ansi ${GEOMETRY_KUBE_NAMESPACE_COLOR:=default} ${kube_namespace:=default})
-
-  if ( ${GEOMETRY_KUBE_VERSION:=true} ); then
-    [[ $(kubectl version --client --short) =~ 'Client Version: ([0-9a-zA-Z.]+)' ]]
-    kube_version=($match[1])
-  fi
-
-  geometry_kube=($kube_symbol $kube_context $kube_namespace $kube_version)
-
-  echo -n ${(pj.$GEOMETRY_KUBE_SEPARATOR.)geometry_kube}
+  local separator=${GEOMETRY_KUBE_SEPARATOR:-"|"}
+  echo -n ${(pj.$separator.)geometry_kube_details}
 }

--- a/functions/geometry_node.zsh
+++ b/functions/geometry_node.zsh
@@ -1,8 +1,8 @@
 # geometry_node - show node and npm/yarm version when in a node project context
 
-(( $+commands[node] )) || return
-
 geometry_node() {
+    (( $+commands[node] )) || return
+
     test -n "$GEOMETRY_NODE_PIN" || test -f package.json || test -f yarn.lock || return 1
 
     GEOMETRY_NODE=$(ansi ${GEOMETRY_NODE_COLOR:=green} ${GEOMETRY_NODE_SYMBOL="⬡"})

--- a/functions/geometry_ruby.zsh
+++ b/functions/geometry_ruby.zsh
@@ -1,8 +1,8 @@
 # geometry_ruby - display the current ruby version, rvm version, and gemset
 
-(( $+commands[ruby] )) || return
-
 geometry_ruby() {
+  (( $+commands[ruby] )) || return
+
   GEOMETRY_RUBY=$(ansi ${GEOMETRY_RUBY_COLOR:=default} ${GEOMETRY_RUBY_SYMBOL:="◆"})
 
   [[ $(ruby -v) =~ 'ruby ([0-9a-zA-Z.]+)' ]]

--- a/functions/geometry_rustup.zsh
+++ b/functions/geometry_rustup.zsh
@@ -1,8 +1,8 @@
 # geometry_rustup - display a symbol colored with the currently selected rustup toolchain
 
-(( $+commands[rustup] )) || return
-
 geometry_rustup() {
+    (( $+commands[rustup] )) || return
+
     ( ${GEOMETRY_RUSTUP_PIN:=false} ) || { cargo locate-project 2>/dev/null || { echo -n '' && return; } }
 
     : ${GEOMETRY_RUSTUP_STABLE_COLOR:=green}

--- a/functions/geometry_status.zsh
+++ b/functions/geometry_status.zsh
@@ -7,9 +7,6 @@ geometry_status() {
   : ${GEOMETRY_STATUS_SYMBOL_ERROR:=△}
   : ${GEOMETRY_STATUS_SYMBOL_ROOT:=▼}
   : ${GEOMETRY_STATUS_SYMBOL_ROOT_ERROR:=▽}
-  : ${GEOMETRY_STATUS_SHOW_CODE:=false}
-  : ${GEOMETRY_STATUS_CODE_PREFIX:=' '}
-  : ${GEOMETRY_STATUS_CODE_SUFFIX:=' '}
 
   ( ${GEOMETRY_STATUS_SYMBOL_COLOR_HASH:=false} ) && {
     local colors=({1..9})
@@ -33,6 +30,5 @@ geometry_status() {
   [[ $UID = 0 || $EUID = 0 ]] && symbol+=_ROOT
   (( $GEOMETRY_LAST_STATUS )) && symbol+=_ERROR && color+=_ERROR
 
-  [[ $GEOMETRY_LAST_STATUS != 0 && $GEOMETRY_STATUS_SHOW_CODE = true ]] && error_code="$GEOMETRY_STATUS_CODE_PREFIX$GEOMETRY_LAST_STATUS$GEOMETRY_STATUS_CODE_SUFFIX"
-  ansi ${(P)color} "$error_code${(P)symbol}"
+  ansi ${(P)color} ${(P)symbol}
 }

--- a/functions/geometry_status.zsh
+++ b/functions/geometry_status.zsh
@@ -7,6 +7,9 @@ geometry_status() {
   : ${GEOMETRY_STATUS_SYMBOL_ERROR:=△}
   : ${GEOMETRY_STATUS_SYMBOL_ROOT:=▼}
   : ${GEOMETRY_STATUS_SYMBOL_ROOT_ERROR:=▽}
+  : ${GEOMETRY_STATUS_SHOW_CODE:=false}
+  : ${GEOMETRY_STATUS_CODE_PREFIX:=' '}
+  : ${GEOMETRY_STATUS_CODE_SUFFIX:=' '}
 
   ( ${GEOMETRY_STATUS_SYMBOL_COLOR_HASH:=false} ) && {
     local colors=({1..9})
@@ -30,5 +33,6 @@ geometry_status() {
   [[ $UID = 0 || $EUID = 0 ]] && symbol+=_ROOT
   (( $GEOMETRY_LAST_STATUS )) && symbol+=_ERROR && color+=_ERROR
 
-  ansi ${(P)color} ${(P)symbol}
+  [[ $GEOMETRY_LAST_STATUS != 0 && $GEOMETRY_STATUS_SHOW_CODE = true ]] && error_code="$GEOMETRY_STATUS_CODE_PREFIX$GEOMETRY_LAST_STATUS$GEOMETRY_STATUS_CODE_SUFFIX"
+  ansi ${(P)color} "$error_code${(P)symbol}"
 }

--- a/geometry.zsh
+++ b/geometry.zsh
@@ -13,7 +13,7 @@ GEOMETRY_ROOT=${0:A:h}
 
 autoload -U add-zsh-hook
 
-for fun in "${GEOMETRY_ROOT}"/functions/geometry_*.zsh; do . $fun; done
+function { local fun; for fun ("${GEOMETRY_ROOT}"/functions/geometry_*.zsh(N.)) . $fun }
 
 (( $+functions[ansi] )) || ansi() { (($# - 2)) || echo -n "%F{$1}$2%f"; }
 

--- a/geometry.zsh
+++ b/geometry.zsh
@@ -51,7 +51,7 @@ add-zsh-hook precmd geometry::clear_title
 
 # join outputs of functions - pwd first
 geometry::wrap() {
-    GEOMETRY_LAST_STATUS="$status"
+    # GEOMETRY_LAST_STATUS="$status"
     local -a outputs
     local pwd=$1
     local cmd
@@ -78,6 +78,7 @@ geometry::rprompt() {
 }
 
 geometry::prompt() {
+  GEOMETRY_LAST_STATUS="$status"
   PROMPT="$(geometry::wrap $PWD $GEOMETRY_PROMPT)$GEOMETRY_SEPARATOR"
   geometry::rprompt
 }

--- a/readme.md
+++ b/readme.md
@@ -83,12 +83,16 @@ GEOMETRY_STATUS_COLOR_ERROR="magenta"  # prompt symbol color when exit value is 
 GEOMETRY_STATUS_COLOR="white"          # prompt symbol color
 GEOMETRY_STATUS_COLOR_ROOT="red"       # root prompt symbol color
 GEOMETRY_STATUS_COLOR_HASH=true        # color status symbol based on hostname
-GEOMETRY_STATUS_SHOW_CODE=false        # show the exit code of failed commands
-GEOMETRY_STATUS_CODE_PREFIX=' '        # prefix for the exit code
-GEOMETRY_STATUS_CODE_SUFFIX=' '        # suffix for the exit code
 ```
 
 ![colorize](/images/screenshots/colorize.png)
+
+### geometry_exitcode
+This renders the exit code of the previous function if it is not success.
+
+```shell
+GEOMETRY_EXITCODE_COLOR="red" # exit code color
+```
 
 ### geometry_git
 

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,9 @@ GEOMETRY_STATUS_COLOR_ERROR="magenta"  # prompt symbol color when exit value is 
 GEOMETRY_STATUS_COLOR="white"          # prompt symbol color
 GEOMETRY_STATUS_COLOR_ROOT="red"       # root prompt symbol color
 GEOMETRY_STATUS_COLOR_HASH=true        # color status symbol based on hostname
+GEOMETRY_STATUS_SHOW_CODE=false        # show the exit code of failed commands
+GEOMETRY_STATUS_CODE_PREFIX=' '        # prefix for the exit code
+GEOMETRY_STATUS_CODE_SUFFIX=' '        # suffix for the exit code
 ```
 
 ![colorize](/images/screenshots/colorize.png)

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,9 @@ GEOMETRY_STATUS_COLOR_ERROR="magenta"  # prompt symbol color when exit value is 
 GEOMETRY_STATUS_COLOR="default"        # prompt symbol color
 GEOMETRY_STATUS_COLOR_ROOT="red"       # root prompt symbol color
 GEOMETRY_STATUS_COLOR_HASH=true        # color status symbol based on hostname
+GEOMETRY_STATUS_SHOW_CODE=false        # show the exit code of failed commands
+GEOMETRY_STATUS_CODE_PREFIX=' '        # prefix for the exit code
+GEOMETRY_STATUS_CODE_SUFFIX=' '        # suffix for the exit code
 ```
 
 ![colorize](/images/screenshots/colorize.png)

--- a/readme.md
+++ b/readme.md
@@ -83,12 +83,16 @@ GEOMETRY_STATUS_COLOR_ERROR="magenta"  # prompt symbol color when exit value is 
 GEOMETRY_STATUS_COLOR="default"        # prompt symbol color
 GEOMETRY_STATUS_COLOR_ROOT="red"       # root prompt symbol color
 GEOMETRY_STATUS_COLOR_HASH=true        # color status symbol based on hostname
-GEOMETRY_STATUS_SHOW_CODE=false        # show the exit code of failed commands
-GEOMETRY_STATUS_CODE_PREFIX=' '        # prefix for the exit code
-GEOMETRY_STATUS_CODE_SUFFIX=' '        # suffix for the exit code
 ```
 
 ![colorize](/images/screenshots/colorize.png)
+
+### geometry_exitcode
+This renders the exit code of the previous function if it is not success.
+
+```shell
+GEOMETRY_EXITCODE_COLOR="red" # exit code color
+```
 
 ### geometry_git
 


### PR DESCRIPTION
As requested, I've ported this to the `mnml` branch. After looking at the `status` function, I figured that it made a lot of sense to have this as an option of status, so I added a configuration to show exit status.

If you'd prefer this to be a standalone function (to make it possible to have it in RPROMPT or INFO instead, let me know.