### PR TITLE
Refactor kube

### DIFF
--- a/functions/geometry_kube.zsh
+++ b/functions/geometry_kube.zsh
@@ -1,31 +1,38 @@
 # geometry_kube - show kubectl client version and current context/namespace.
+geometry_kube_symbol() {
+  ansi ${GEOMETRY_KUBE_COLOR:=blue} ${GEOMETRY_KUBE_SYMBOL:="⎈"}
+}
+
+geometry_kube_namespace() {
+  local kube_namespace=$(kubectl config view --minify --output "jsonpath={..namespace}" 2> /dev/null)
+  ansi ${GEOMETRY_KUBE_NAMESPACE_COLOR:=default} ${kube_namespace:=default}
+}
+
+geometry_kube_context() {
+  local kube_context="$(kubectl config current-context 2> /dev/null)"
+  ansi ${GEOMETRY_KUBE_CONTEXT_COLOR:=default} ${kube_context}
+}
+
+geometry_kube_version() {
+  [[ $(kubectl version --client --short) =~ 'Client Version: ([0-9a-zA-Z.]+)' ]]
+  local kube_version=($match[1])
+  ansi ${GEOMETRY_KUBE_VERSION_COLOR:=default} ${kube_version:=default}
+}
 
 geometry_kube() {
   (( $+commands[kubectl] )) || return
-  ( ${GEOMETRY_KUBE_PIN:=false} ) || [[ -n "$KUBECONFIG" ]] || return
-  : ${GEOMETRY_KUBE_SEPARATOR:="|"}
 
-  # Variable declaration
-  local -a geometry_kube
-  local kube_symbol
-  local kube_context
-  local kube_namespace
-  local kube_version
+  ( ${GEOMETRY_KUBE_PIN:=true} ) || return
 
-  kube_symbol=$(ansi ${GEOMETRY_KUBE_COLOR:=blue} ${GEOMETRY_KUBE_SYMBOL:="⎈"})
+  ( ${GEOMETRY_KUBE_PIN:=false} ) || [[ -n "$KUBECONFIG" ]] || [[ -n "$(kubectl config current-context 2> /dev/null)" ]] || return
 
-  kube_context="$(kubectl config current-context 2> /dev/null)"
-  kube_context=$(ansi ${GEOMETRY_KUBE_CONTEXT_COLOR:=default} ${kube_context})
+  local geometry_kube_details && geometry_kube_details=(
+    $(geometry_kube_symbol)
+    $(geometry_kube_context)
+    $(geometry_kube_namespace)
+    $(geometry_kube_version)
+  )
 
-  kube_namespace=$(kubectl config view -o "jsonpath={.contexts[?(@.name==\"${kube_context}\")].context.namespace}" 2> /dev/null)
-  kube_namespace=$(ansi ${GEOMETRY_KUBE_NAMESPACE_COLOR:=default} ${kube_namespace:=default})
-
-  if ( ${GEOMETRY_KUBE_VERSION:=true} ); then
-    [[ $(kubectl version --client --short) =~ 'Client Version: ([0-9a-zA-Z.]+)' ]]
-    kube_version=($match[1])
-  fi
-
-  geometry_kube=($kube_symbol $kube_context $kube_namespace $kube_version)
-
-  echo -n ${(pj.$GEOMETRY_KUBE_SEPARATOR.)geometry_kube}
+  local separator=${GEOMETRY_KUBE_SEPARATOR:-"|"}
+  echo -n ${(pj.$separator.)geometry_kube_details}
 }


### PR DESCRIPTION
Use better approach for retreiving current namespace that doesn't rely on
getting context first.

Use the geometry_kube_{namespace, symbol, context, version} convention to
make this function similar to the git function.

Detect a valid current context in addition to a non-zero KUBECONFIG.

Add GEOMETRY_KUBE_VERSION_COLOR.
Remove GEOMETRY_KUBE_VERSION check, as you can remove this element now
with by intentionally excluding geometry_kube_version from your prompt.

Added some different logic to pinning. If you have have GEOMETRY_KUBE_PIN
unset, then it defaults to false and displays prompt extras only if
valid KUBECONFIG or kubectl get current-context is valid. If explictly
set to false, then it will not display at all. If set to true, then it
displays all the time regardless of a valid context.