### PR TITLE
Unhide the geometry separator

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -6,7 +6,7 @@
 
 typeset -gA GEOMETRY
 GEOMETRY[ROOT]=${0:A:h}
-: ${GEOMETRY[SEPARATOR]:=" "}
+: ${GEOMETRY_SEPARATOR:=" "}
 
 (($+GEOMETRY_PROMPT)) || GEOMETRY_PROMPT=(geometry_echo geometry_status geometry_path)
 (($+GEOMETRY_RPROMPT)) || GEOMETRY_RPROMPT=(geometry_exec_time geometry_git geometry_hg geometry_echo)


### PR DESCRIPTION
The `GEOMETRY_SEPARATOR` still being used in the following places:

- https://github.com/geometry-zsh/geometry/blob/mnml/geometry.zsh#L81
- https://github.com/geometry-zsh/geometry/blob/mnml/geometry.zsh#L61
- https://github.com/geometry-zsh/geometry/blob/mnml/readme.md#general

Since it's exposed to the user, hiding it may be a **BREAKING CHANGE**.