### PR TITLE
Refactor geometry_git_symbol into geometry_git

### DIFF
--- a/functions/geometry_git
+++ b/functions/geometry_git
@@ -50,8 +50,6 @@ geometry_git_remote() {
   echo "$unpushed $unpulled"
 }
 
-geometry_git_symbol() { echo ${(j: :):-$(geometry_git_rebase) $(geometry_git_remote)}; }
-
 geometry_git_conflicts() {
   local _grep
   local conflicts conflict_list
@@ -87,7 +85,8 @@ geometry_git() {
     && return
 
   local git_info && git_info=(
-    geometry_git_symbol
+    geometry_git_rebase
+    geometry_git_remote
     geometry_git_branch
     geometry_git_conflicts
     geometry_git_time


### PR DESCRIPTION
#### Description
This PR refactors the `geometry_git_symbol()` function into the main `geometry_git()` function().

With the recent refactoring of printing function-output with `geometry::wrap()`, the array-joining in `geometry_git_symbol()` is now un-needed. The call to sub-functions should therefore be included in the main-function.
#### To-fix
The current behaviour of `geometry_git_symbol()` would always insert one un-needed space if only one of the called sub-functions is called. Using `geometry::wrap()` fixes that (please note the spacing around the "remote"-icon):
![demo](https://user-images.githubusercontent.com/46794176/73570032-7bf00500-4463-11ea-93b8-e9c581ff2056.png)
I also took a look into the other functions, but found no oppurtunitys where this could also be done (I guess `geometry_git_symbol()` was just accidentally missed in the previous refactoring).