### PR TITLE
Fix git conflict counting with multiple files

### DIFF
--- a/functions/geometry_git
+++ b/functions/geometry_git
@@ -60,7 +60,8 @@ geometry_git_conflicts() {
   [[ -z "$conflicts" ]] && return
 
   _grep=${GEOMETRY_GIT_GREP:=${commands[rg]:=${commands[ag]:=${commands[grep]}}}}
-  conflict_list=$($_grep -cH '^=======$' $conflicts)
+  # Replacing \n with \0 since the -0 xargs flag is more portable than -d '\n'
+  conflict_list=$(echo $conflicts | tr '\n' '\0' | xargs -0 $_grep -cH '^=======$')
 
   raw_file_count="${#${(@f)conflict_list}}"
   file_count=${raw_file_count##*( )}


### PR DESCRIPTION
When the `$conflicts` shell variable contains newlines, the `$_grep` command attempts to read the entire output as a single file. This results in "No such file or directory" errors.

The fix here uses `xargs` to pass each file name individually.

I was seeing this on macoS 10.15.4 with zsh 5.8 (x86_64-apple-darwin19.3.0).

<img width="842" alt="Screen Shot 2020-04-19 at 3 50 16 PM" src="https://user-images.githubusercontent.com/906558/79698224-17309380-8277-11ea-8caa-a811d57d3ac8.png">