### PR TITLE
Fix whitespace escape in git_status

### DIFF
--- a/functions/geometry_git
+++ b/functions/geometry_git
@@ -23,7 +23,7 @@ geometry_git_status() {
   command git rev-parse --git-dir > /dev/null 2>&1 || return
 
   [[ -z "$(git status --porcelain --ignore-submodules HEAD)" ]] \
-  && [[ -z "$(git ls-files --others --modified --exclude-standard $(git rev-parse --show-toplevel))" ]] \
+  && [[ -z "$(git ls-files --others --modified --exclude-standard \"$(git rev-parse --show-toplevel))\"" ]] \
   && ansi ${GEOMETRY_GIT_COLOR_CLEAN:-green} ${GEOMETRY_GIT_SYMBOL_CLEAN:-"⬢"} \
   || ansi ${GEOMETRY_GIT_COLOR_DIRTY:-red} ${GEOMETRY_GIT_SYMBOL_DIRTY:-"⬡"}
 }


### PR DESCRIPTION
In git_status, when path to git dir contains whitespace
`git ls-files` receives only part of that path and shows kinda annoying fatal error