### PR TITLE
Fix git conflict counting with multiple files, thanks @gluxon

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+### Fixed
 - Fix git functions erroring out in non-git directories (thanks @duncanbeevers!)
+- Git conflict counting with multiple files (thanks @gluxon!)
 
 ## 2.2.0 - 2020-01-13
 
@@ -21,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - lazy load functions with autoload instead of sourcing (thanks @alxbl!)
 
 ### Added
-- geometry_newline for two-line prompts (thanks @ducklin5)
+- geometry_newline for two-line prompts (thanks @ducklin5!)
 - geometry::hostcolor to allow host-based colorization for all (thanks @crasx!)
 
 ### Fixed
@@ -105,8 +108,9 @@ Now uses GEOMETRY_SEPARATOR like everything else.
 - Dozens of other small fixes
 
 ## 1.0.0 - 2017-04-05
+
 ### Added
 - Change Log file
 - Initial release features
 
-[Unreleased]: https://github.com/geometry-zsh/geometry/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/geometry-zsh/geometry/compare/v2.2.0...HEAD

--- a/functions/geometry_git
+++ b/functions/geometry_git
@@ -57,21 +57,22 @@ geometry_git_remote() {
   echo "$unpushed $unpulled"
 }
 
+geometry_git_symbol() { echo ${(j: :):-$(geometry_git_rebase) $(geometry_git_remote)}; }
+
 geometry_git_conflicts() {
   _geometry_git_guard || return
   local _grep
   local conflicts conflict_list
-  local file_count raw_file_count
+  local file_count
   local total raw_total
-  conflicts=$(git diff --name-only --diff-filter=U)
+  conflicts=$(git diff --name-only --diff-filter=U -z)
 
   [[ -z "$conflicts" ]] && return
 
   _grep=${GEOMETRY_GIT_GREP:=${commands[rg]:=${commands[ag]:=${commands[grep]}}}}
-  conflict_list=$($_grep -cH '^=======$' $conflicts)
+  conflict_list=$($_grep -cH '^=======$' ${(0)conflicts})
 
-  raw_file_count="${#${(@f)conflict_list}}"
-  file_count=${raw_file_count##*( )}
+  file_count="${(w)#conflict_list}"
 
   raw_total=$(echo $conflict_list | cut -d ':' -f2 | paste -sd+ - | bc)
   total=${raw_total##*(  )}


### PR DESCRIPTION
@gluxon came up with a solution to "no such file or directory"
errors, which exposed underlying issues with our git conflict counting.

The solution was to use null characters and xargs instead of newlines.

`git diff` has the `-z` flag to list names with \0 instead of \n,
and zsh has an expansion modifier `0` which expands on \0 instead of \n.

This also fixes the `20f` issue when only one file has conflicts, it
was counting characters of the filename instead of the file list.

Thank you @gluxon!