### PR TITLE
Allow customization of terminal title

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Add GEOMETRY_TITLE and GEOMETRY_CMDTITLE as display locations
+- Add geometry_cmd function to display currently-running command in GEOMETRY_CMDTITLE
 
 ### Fixed
 - Fix git functions erroring out in non-git directories (thanks @duncanbeevers!)

--- a/readme.md
+++ b/readme.md
@@ -43,16 +43,26 @@ tool          | add to `.zshrc`
 
 ![showing prompt customization with new function](./images/screenshots/functions.png)
 
-Geometry has very little architecture. Three environment variables define what is shown on the left, right, and on enter - `GEOMETRY_PROMPT`, `GEOMETRY_RPROMPT`, and `GEOMETRY_INFO`.
+Geometry displays output in several places. The output displayed in each location is determined by the plugins configured for that location.
+These are the supported locations, along with the environment variable used to configure each one.
 
-Most of these functions only show up if it makes sense to (for example, `geometry_git` only shows up if in a git repository).
+Variable Name        | Text display location                                             
+---------------------|-------------------------------------------------------
+GEOMETRY_PROMPT      | Text shown to the left of the cursor
+GEOMETRY_RPROMPT     | Text shown at the right edge of the terminal
+GEOMETRY_INFO        | Text shown after pressing enter with no input
+GEOMETRY_TITLE       | Text shown in the terminal title
+GEOMETRY_CMDTITLE    | Text shown in the terminal title when a command is run
 
-To customize the prompt, just add any function to any of the `GEOMETRY_PROMPT`, `GEOMETRY_RPROMPT`, or `GEOMETRY_INFO` variables:
+To customize the prompt, add any function to the list of functions for the desired display location:
 
 ```sh
 GEOMETRY_PROMPT=(geometry_status geometry_path) # redefine left prompt
 GEOMETRY_RPROMPT+=(geometry_exec_time pwd)      # append exec_time and pwd right prompt
+GEOMETRY_TITLE=(geometry_node)
 ```
+
+Most of these functions only show up if it makes sense to (for example, `geometry_git` only shows up if in a git repository).
 
 Please check out and share third-party functions on our [functions wiki page][]
 


### PR DESCRIPTION
### Summary
Previously, geometry showed output in three locations:
* `GEOMETRY_PROMPT`
* `GEOMETRY_RPROMPT`
* `GEOMETRY_INFO`

This PR adds two new display locations:
* `GEOMETRY_TITLE`
* `GEOMETRY_RUNTITLE`

### Details

Geometry was already implicitly updating the terminal title.
This PR allows configuration of these locations through the same paradigm as drives the rest of geometry.

The original title-controlling functions; `geometry::clear_title`, and `geometry::set_title` ran with an implicit lifecycle.

### Challenges

#### De-coloring

The biggest challenge with this PR was de-coloring the output of geometry plugins.
The `deansi` function included here is hand-rolled and worked with the handful of functions I tried out; including`geometry_path`,`geometry_node`, and `geometry_hostname`.

#### Limited testing

I've primarily developed/tested this in iTerm. It looks a little funny in Terminal.app
iTerm | Terminal.app
-|-
![2020-09-20 at 12 47 PM](https://user-images.githubusercontent.com/7367/93720689-7c96f200-fb3f-11ea-9c79-8bfea9dfc811.png) | ![2020-09-20 at 12 43 PM](https://user-images.githubusercontent.com/7367/93720621-190cc480-fb3f-11ea-8d87-9338372646a3.png)

#### No current command

This PR is a regression, since the currently-executing command is no longer exposed in the terminal title.
It seems simplest to expose it as a generic geometry function, like `geometry_cmd` or something, but it may only be useful when used in `GEOMETRY_RUNTITLE`.
