### PR TITLE
Silence a git warning in a repo without a HEAD

### DIFF
--- a/functions/geometry_git
+++ b/functions/geometry_git
@@ -28,7 +28,7 @@ geometry_git_branch() {
 geometry_git_status() {
   command git rev-parse --git-dir > /dev/null 2>&1 || return
 
-  git diff-index --quiet HEAD \
+  git diff-index --quiet HEAD 2> /dev/null \
   && [[ -z "$(git status --porcelain --ignore-submodules)" ]] \
   && ansi ${GEOMETRY_GIT_COLOR_CLEAN:-green} ${GEOMETRY_GIT_SYMBOL_CLEAN:-"⬢"} \
   || ansi ${GEOMETRY_GIT_COLOR_DIRTY:-red} ${GEOMETRY_GIT_SYMBOL_DIRTY:-"⬡"}


### PR DESCRIPTION
If you run `mkdir x && cd x && git init` with geometry prompt, then you'll start seeing this error all the time:

```
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

It turns out that error is coming from running `git diff-index --quiet HEAD` in `geometry_git_status` and was introduced a few months ago. But that error is actually not a big deal; it's more like a warning given this use case. This commit silences that warning.