### PR TITLE
Allow customizing path truncation

### DIFF
--- a/functions/geometry_path
+++ b/functions/geometry_path
@@ -1,7 +1,7 @@
 # geometry_path - show the current path
 
 geometry_path() {
-  local dir=${GEOMETRY_PATH_SYMBOL_HOME:-"%3~"}   # symbol representing the home directory
+  local dir=${GEOMETRY_PATH_SYMBOL_HOME:-"%$GEOMETRY_PATH_TRUNCATE~"}   # symbol representing the home directory
   ( ${GEOMETRY_PATH_SHOW_BASENAME:-false} ) && dir=${PWD:t}
   ansi ${GEOMETRY_PATH_COLOR:-blue} $dir
 }

--- a/geometry.zsh
+++ b/geometry.zsh
@@ -11,6 +11,7 @@ typeset -gA GEOMETRY; GEOMETRY[ROOT]=${0:A:h}
 (($+GEOMETRY_INFO)) || GEOMETRY_INFO=()
 (($+GEOMETRY_TITLE)) || GEOMETRY_TITLE=(geometry_path)
 (($+GEOMETRY_CMDTITLE)) || GEOMETRY_CMDTITLE=(geometry_cmd geometry_hostname)
+(($+GEOMETRY_PATH_TRUNCATE)) || GEOMETRY_PATH_TRUNCATE=3
 
 autoload -U add-zsh-hook
 


### PR DESCRIPTION
Replaced hard-coded 3 with `GEOMETRY_PATH_TRUNCATE` variable (defaults to 3).
Now maximum amount of directories to show can be customized by setting that variable.

This is implemented a little different to how the other defaults are implemented, but it seemed more efficient to just set the variable to the default if it wasn't set, because the variable needs to be checked anyway.