### PR TITLE
Silence warnings about line endings

### DIFF
--- a/functions/geometry_git
+++ b/functions/geometry_git
@@ -65,7 +65,7 @@ geometry_git_conflicts() {
   local conflicts conflict_list
   local file_count
   local total raw_total
-  conflicts=$(git diff --name-only --diff-filter=U -z)
+  conflicts=$(git diff --name-only --diff-filter=U -z 2>/dev/null)
 
   [[ -z "$conflicts" ]] && return
 


### PR DESCRIPTION
I was opening a repo that had a mix of line-endings, and I got warnings about line ending changes on every prompt; since they aren't useful when repeated at every prompt, I identified the command that was producing them and directed it's stderr to `/dev/null`. 