### PR TITLE
Compatibility with znap

### DIFF
--- a/geometry.zsh
+++ b/geometry.zsh
@@ -15,7 +15,7 @@ typeset -gA GEOMETRY; GEOMETRY[ROOT]=${0:A:h}
 
 autoload -U add-zsh-hook
 
-function { local fun; for fun ("${GEOMETRY[ROOT]}"/functions/*) . $fun }
+() { setopt localoptions extendedglob; for fun ("$GEOMETRY[ROOT]"/functions/^*.zwc) . $fun }
 
 (( $+functions[ansi] )) || ansi() { (($# - 2)) || echo -n "%F{$1}$2%f"; }
 (( $+functions[deansi] )) || deansi() { (($# - 1)) || echo -n "$(echo "$1" | sed s/$(echo "\033")\\\[\[0-9\]\\\{1,2\\\}m//g)"; }

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ tool          | add to `.zshrc`
 --------------|--------------------------------------
 [zr][]        | `zr geometry-zsh/geometry`
 [zplug][]     | `zplug "geometry-zsh/geometry"`
+[znap][]     | `znap prompt geometry-zsh/geometry`
 [antigen][]   | `antigen theme geometry-zsh/geometry`
 [Homebrew][]  | `brew install geometry`
 **manually**  | `source geometry/geometry.zsh` (after `git clone https://github.com/geometry-zsh/geometry`)
@@ -142,6 +143,7 @@ A big thank you to the dozens of [additional contributors](https://github.com/ge
 
 [functions wiki page]: https://github.com/geometry-zsh/geometry/wiki/functions
 [open an issue]: https://github.com/geometry-zsh/geometry/issues/new
+[znap]: https://github.com/marlonrichert/zsh-snap
 [zr]: https://github.com/jedahan/zr
 [zplug]: https://github.com/zplug/zplug
 [antigen]: https://github.com/zsh-users/antigen


### PR DESCRIPTION
Geometry currently doesn't work with [znap](https://github.com/marlonrichert/zsh-snap). Details here: https://github.com/marlonrichert/zsh-snap/issues/67

This PR fixes that problem without changing any Geometry behaviors + documents how to install with znap.